### PR TITLE
feat: additional node labels

### DIFF
--- a/pkg/apis/v1alpha1/labels.go
+++ b/pkg/apis/v1alpha1/labels.go
@@ -26,9 +26,9 @@ const (
 	TerminationFinalizer = apis.Group + "/termination"
 
 	// Labels that can be selected on and are propagated to the node
-	LabelInstanceFamily          = apis.Group + "/instance-family"           // c1, s1, m1, e1
-	LabelInstanceCPUManufacturer = apis.Group + "/instance-cpu-manufacturer" // host, kvm64, Broadwell, Skylake
-	LabelInstanceImageID         = apis.Group + "/instance-image-id"         // image ID
+	LabelInstanceFamily  = apis.Group + "/instance-family"   // c1, s1, m1, e1
+	LabelInstanceCPUType = apis.Group + "/instance-cpu-type" // host, kvm64, Broadwell, Skylake
+	LabelInstanceImageID = apis.Group + "/instance-image-id" // image ID
 
 	// github.com/awslabs/eks-node-viewer label so that it shows up.
 	LabelNodeViewer = "eks-node-viewer/instance-price"
@@ -38,7 +38,7 @@ func init() {
 	karpv1.RestrictedLabelDomains = karpv1.RestrictedLabelDomains.Insert(apis.Group)
 	karpv1.WellKnownLabels = karpv1.WellKnownLabels.Insert(
 		LabelInstanceFamily,
-		LabelInstanceCPUManufacturer,
+		LabelInstanceCPUType,
 		LabelInstanceImageID,
 	)
 }

--- a/pkg/providers/instancetype/instancetype.go
+++ b/pkg/providers/instancetype/instancetype.go
@@ -191,7 +191,8 @@ func (p *DefaultProvider) computeRequirements(instanceTypeName string, _ []*clou
 
 		// Well Known to Proxmox
 		scheduling.NewRequirement(v1alpha1.LabelInstanceFamily, corev1.NodeSelectorOpIn, strings.Split(instanceTypeName, ".")[0]),
-		scheduling.NewRequirement(v1alpha1.LabelInstanceCPUManufacturer, corev1.NodeSelectorOpDoesNotExist),
+		scheduling.NewRequirement(v1alpha1.LabelInstanceCPUType, corev1.NodeSelectorOpDoesNotExist),
+		scheduling.NewRequirement(v1alpha1.LabelInstanceImageID, corev1.NodeSelectorOpDoesNotExist),
 	)
 
 	return requirements

--- a/pkg/providers/proxmox/types.go
+++ b/pkg/providers/proxmox/types.go
@@ -39,6 +39,19 @@ type VMCloneRequest struct {
 	InstanceType string `json:"instanceType,omitempty"`
 }
 
+type VMCPU struct {
+	Flags *[]string `json:"flags,omitempty"`
+	Type  string    `json:"cputype,omitempty"`
+}
+
+func (r *VMCPU) UnmarshalString(s string) error {
+	return unmarshal(s, r)
+}
+
+func (r *VMCPU) ToString() (string, error) {
+	return marshal(r)
+}
+
 type VMSMBIOS struct {
 	Base64       *proxmox.IntOrBool `json:"base64,omitempty" `
 	Family       string             `json:"family,omitempty"`


### PR DESCRIPTION
Add the instance-cpu-type and instance-image-id labels to the node when it joins the cluster.

# Pull Request

## What? (description)

## Why? (reasoning)

## Acceptance

Please use the following checklist:

- [ ] you linked an issue (if applicable)
- [ ] you included tests (if applicable)
- [ ] you linted your code (`make lint`)
- [ ] you linted your code (`make unit`)

> See `make help` for a description of the available targets.
