### PR TITLE
feat: remember proxmox virtual machine last id

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ SHA ?= $(shell git describe --match=none --always --abbrev=7 --dirty)
 TAG ?= $(VERSION)
 
 GO_LDFLAGS := -s -w
-GO_LDFLAGS += -X sigs.k8s.io/karpenter/pkg/operator.Version=$(VERSION)
+GO_LDFLAGS += -X sigs.k8s.io/karpenter/pkg/operator.Version=$(TAG)
 
 OS ?= $(shell go env GOOS)
 ARCH ?= $(shell go env GOARCH)

--- a/README.md
+++ b/README.md
@@ -92,8 +92,8 @@ spec:
   metadataOptions:
     # How delivery the metadata to the VM, options: none or cdrom (required)
     type: none|cdrom
-    # SecretRef is used if the type is `cdrom`, that contains cloud-init metadata templates
-    secretRef:
+    # templatesRef is used if the type is `cdrom`, that contains cloud-init metadata templates
+    templatesRef:
       name: ubuntu-k8s
       namespace: kube-system
 

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/go-logr/logr v1.4.3
 	github.com/luthermonson/go-proxmox v0.2.3-0.20250815182455-16138a778fb5
 	github.com/mitchellh/hashstructure/v2 v2.0.2
+	github.com/patrickmn/go-cache v2.1.0+incompatible
 	github.com/pkg/errors v0.9.1
 	github.com/samber/lo v1.51.0
 	github.com/spf13/cobra v1.9.1
@@ -53,7 +54,6 @@ require (
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
-	github.com/patrickmn/go-cache v2.1.0+incompatible // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/prometheus/client_golang v1.23.0 // indirect
 	github.com/prometheus/client_model v0.6.2 // indirect

--- a/pkg/providers/instance/instance.go
+++ b/pkg/providers/instance/instance.go
@@ -241,7 +241,6 @@ func (p *DefaultProvider) instanceCreate(ctx context.Context,
 		return nil, fmt.Errorf("failed to get proxmox cluster with region name %s: %v", region, err)
 	}
 
-	// FIXME: Need random ID generator
 	newID, err := px.GetNextID(ctx, options.FromContext(ctx).ProxmoxVMID)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get next id: %v", err)


### PR DESCRIPTION
It reduces unnecessary API calls and prevents other kubernetes add-ons from running into VM ID collisions.

# Pull Request

## What? (description)

## Why? (reasoning)

## Acceptance

Please use the following checklist:

- [ ] you linked an issue (if applicable)
- [ ] you included tests (if applicable)
- [ ] you linted your code (`make lint`)
- [ ] you linted your code (`make unit`)

> See `make help` for a description of the available targets.
