### PR TITLE
feat: detach cloud-init iso

### DIFF
--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -63,6 +63,7 @@ func main() {
 			op.GetClient(),
 			op.EventRecorder,
 			cloudProvider,
+			op.InstanceProvider,
 			op.InstanceTemplateProvider,
 			op.CloudCapacityProvider,
 		)...).

--- a/pkg/apis/v1alpha1/annotations.go
+++ b/pkg/apis/v1alpha1/annotations.go
@@ -36,4 +36,7 @@ const (
 
 	// AnnotationProxmoxTemplateClassHashVersion is the annotation key for the version of the hash function
 	AnnotationProxmoxTemplateClassHashVersion = apis.Group + "/proxmoxtemplateclass-hash-version"
+
+	// AnnotationProxmoxCloudInitStatus is the annotation key for the status of the ProxmoxCloudInit
+	AnnotationProxmoxCloudInitStatus = apis.Group + "/proxmoxcloudinit-status"
 )

--- a/pkg/controllers/controllers.go
+++ b/pkg/controllers/controllers.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/awslabs/operatorpkg/controller"
 
+	nodeclaimlifecycle "github.com/sergelogvinov/karpenter-provider-proxmox/pkg/controllers/nodeclaim/lifecycle"
 	nodeclasshash "github.com/sergelogvinov/karpenter-provider-proxmox/pkg/controllers/nodeclass/hash"
 	nodeclaasstatus "github.com/sergelogvinov/karpenter-provider-proxmox/pkg/controllers/nodeclass/status"
 	nodetemplateclasshash "github.com/sergelogvinov/karpenter-provider-proxmox/pkg/controllers/nodetemplateclass/hash"
@@ -30,6 +31,7 @@ import (
 	cloudcapacitynode "github.com/sergelogvinov/karpenter-provider-proxmox/pkg/controllers/providers/cloudcapacity/node"
 	cloudcapacitynodeload "github.com/sergelogvinov/karpenter-provider-proxmox/pkg/controllers/providers/cloudcapacity/nodeload"
 	"github.com/sergelogvinov/karpenter-provider-proxmox/pkg/providers/cloudcapacity"
+	"github.com/sergelogvinov/karpenter-provider-proxmox/pkg/providers/instance"
 	"github.com/sergelogvinov/karpenter-provider-proxmox/pkg/providers/instancetemplate"
 
 	"k8s.io/utils/clock"
@@ -43,10 +45,12 @@ import (
 func NewControllers(ctx context.Context, mgr manager.Manager, clk clock.Clock,
 	kubeClient client.Client, recorder events.Recorder,
 	cloudProvider cloudprovider.CloudProvider,
+	instanceProvider instance.Provider,
 	instanceTemplateProvider instancetemplate.Provider,
 	cloudCapacityProvider cloudcapacity.Provider,
 ) []controller.Controller {
 	controllers := []controller.Controller{
+		nodeclaimlifecycle.NewController(kubeClient, cloudProvider, instanceProvider),
 		nodeclasshash.NewController(kubeClient),
 		nodeclaasstatus.NewController(kubeClient, instanceTemplateProvider),
 		nodetemplateclasshash.NewController(kubeClient),

--- a/pkg/controllers/nodeclaim/lifecycle/controller.go
+++ b/pkg/controllers/nodeclaim/lifecycle/controller.go
@@ -1,0 +1,121 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package lifecycle
+
+import (
+	"context"
+
+	"github.com/awslabs/operatorpkg/reasonable"
+	"go.uber.org/multierr"
+
+	"github.com/sergelogvinov/karpenter-provider-proxmox/pkg/providers/instance"
+
+	"k8s.io/apimachinery/pkg/api/equality"
+	"k8s.io/apimachinery/pkg/api/errors"
+
+	controllerruntime "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	karpv1 "sigs.k8s.io/karpenter/pkg/apis/v1"
+	"sigs.k8s.io/karpenter/pkg/cloudprovider"
+	"sigs.k8s.io/karpenter/pkg/operator/injection"
+	"sigs.k8s.io/karpenter/pkg/utils/nodeclaim"
+	"sigs.k8s.io/karpenter/pkg/utils/result"
+)
+
+type nodeClaimLifecycleReconciler interface {
+	Reconcile(context.Context, *karpv1.NodeClaim) (reconcile.Result, error)
+}
+
+type Controller struct {
+	kubeClient         client.Client
+	cloudProvider      cloudprovider.CloudProvider
+	instanceProvider   instance.Provider
+	instanceRegistered *InstanceRegistered
+}
+
+func NewController(kubeClient client.Client, cloudProvider cloudprovider.CloudProvider, instanceProvider instance.Provider) *Controller {
+	return &Controller{
+		kubeClient:       kubeClient,
+		cloudProvider:    cloudProvider,
+		instanceProvider: instanceProvider,
+		instanceRegistered: &InstanceRegistered{
+			kubeClient:       kubeClient,
+			instanceProvider: instanceProvider,
+		},
+	}
+}
+
+func (c *Controller) Name() string {
+	return "nodeclaim.lifecycle.proxmox"
+}
+
+func (c *Controller) Reconcile(ctx context.Context, nodeClaim *karpv1.NodeClaim) (reconcile.Result, error) {
+	ctx = injection.WithControllerName(ctx, c.Name())
+
+	if !nodeClaim.GetDeletionTimestamp().IsZero() {
+		return reconcile.Result{}, nil
+	}
+
+	nodeClaimCopy := nodeClaim.DeepCopy()
+
+	var errs error
+
+	results := []reconcile.Result{}
+
+	for _, reconciler := range []nodeClaimLifecycleReconciler{
+		c.instanceRegistered,
+	} {
+		res, err := reconciler.Reconcile(ctx, nodeClaim)
+		errs = multierr.Append(errs, err)
+
+		results = append(results, res)
+	}
+
+	if !equality.Semantic.DeepEqual(nodeClaimCopy, nodeClaim) {
+		// We use client.MergeFromWithOptimisticLock because patching a list with a JSON merge patch
+		// can cause races due to the fact that it fully replaces the list on a change
+		// https://github.com/kubernetes/kubernetes/issues/111643#issuecomment-2016489732
+		if err := c.kubeClient.Patch(ctx, nodeClaim, client.MergeFromWithOptions(nodeClaimCopy, client.MergeFromWithOptimisticLock{})); err != nil {
+			if errors.IsConflict(err) {
+				return reconcile.Result{Requeue: true}, nil
+			}
+
+			errs = multierr.Append(errs, client.IgnoreNotFound(err))
+		}
+	}
+
+	if errs != nil {
+		return reconcile.Result{}, errs
+	}
+
+	return result.Min(results...), nil
+}
+
+func (c *Controller) Register(_ context.Context, m manager.Manager) error {
+	return controllerruntime.NewControllerManagedBy(m).
+		Named(c.Name()).
+		For(&karpv1.NodeClaim{}, builder.WithPredicates(nodeclaim.IsManagedPredicateFuncs(c.cloudProvider))).
+		WithOptions(controller.Options{
+			RateLimiter:             reasonable.RateLimiter(),
+			MaxConcurrentReconciles: 10,
+		}).
+		Complete(reconcile.AsReconciler(m.GetClient(), c))
+}

--- a/pkg/controllers/nodeclaim/lifecycle/instancetregistered.go
+++ b/pkg/controllers/nodeclaim/lifecycle/instancetregistered.go
@@ -1,0 +1,87 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package lifecycle
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/samber/lo"
+
+	"github.com/sergelogvinov/karpenter-provider-proxmox/pkg/apis/v1alpha1"
+	proxmox "github.com/sergelogvinov/karpenter-provider-proxmox/pkg/cloudprovider"
+	"github.com/sergelogvinov/karpenter-provider-proxmox/pkg/providers/instance"
+
+	"k8s.io/apimachinery/pkg/types"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	karpv1 "sigs.k8s.io/karpenter/pkg/apis/v1"
+)
+
+type InstanceRegistered struct {
+	kubeClient       client.Client
+	instanceProvider instance.Provider
+}
+
+func (i *InstanceRegistered) Reconcile(ctx context.Context, nodeClaim *karpv1.NodeClaim) (reconcile.Result, error) {
+	if !nodeClaim.StatusConditions().Get(karpv1.ConditionTypeInitialized).IsTrue() {
+		return reconcile.Result{}, nil
+	}
+
+	if !strings.HasPrefix(nodeClaim.Status.ProviderID, proxmox.ProxmoxProviderPrefix) {
+		return reconcile.Result{}, nil
+	}
+
+	if _, ok := nodeClaim.Annotations[v1alpha1.AnnotationProxmoxCloudInitStatus]; ok {
+		return reconcile.Result{}, nil
+	}
+
+	nodeClass, err := i.resolveNodeClassFromNodeClaim(ctx, nodeClaim)
+	if err != nil {
+		return reconcile.Result{}, err
+	}
+
+	if nodeClass.Spec.MetadataOptions.Type == "cdrom" {
+		err = i.instanceProvider.DetachCloudInit(ctx, nodeClaim)
+		if err != nil {
+			return reconcile.Result{RequeueAfter: 5 * time.Second}, err
+		}
+	}
+
+	nodeClaim.Annotations = lo.Assign(nodeClaim.Annotations, map[string]string{
+		v1alpha1.AnnotationProxmoxCloudInitStatus: string(karpv1.ConditionTypeInitialized),
+	})
+
+	return reconcile.Result{}, nil
+}
+
+func (i *InstanceRegistered) resolveNodeClassFromNodeClaim(ctx context.Context, nodeClaim *karpv1.NodeClaim) (*v1alpha1.ProxmoxNodeClass, error) {
+	ref := nodeClaim.Spec.NodeClassRef
+	if ref == nil {
+		return nil, fmt.Errorf("nodeClaim missing NodeClassRef")
+	}
+
+	nodeClass := &v1alpha1.ProxmoxNodeClass{}
+	if err := i.kubeClient.Get(ctx, types.NamespacedName{Name: ref.Name}, nodeClass); err != nil {
+		return nil, err
+	}
+
+	return nodeClass, nil
+}


### PR DESCRIPTION
After a new node is initialized, it no longer requires the cloud-init configuration. At this point, we should detach and remove the ISO image from the Proxmox node.

# Pull Request

## What? (description)

## Why? (reasoning)

## Acceptance

Please use the following checklist:

- [ ] you linked an issue (if applicable)
- [ ] you included tests (if applicable)
- [ ] you linted your code (`make lint`)
- [ ] you linted your code (`make unit`)

> See `make help` for a description of the available targets.
