### PR TITLE
feat: expose proxmox host bridge ips

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -85,6 +85,8 @@ linters:
         - fmt.Fprintln
         - fmt.Fprintf
         - fmt.Fprint
+    interfacebloat:
+      max: 15
     goconst:
       min-len: 3
       min-occurrences: 3

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/sergelogvinov/karpenter-provider-proxmox
 go 1.25.1
 
 require (
+	github.com/apparentlymart/go-cidr v1.1.0
 	github.com/awslabs/operatorpkg v0.0.0-20250804204931-57066b748e19
 	github.com/go-logr/logr v1.4.3
 	github.com/luthermonson/go-proxmox v0.2.3-0.20250815182455-16138a778fb5

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 github.com/Pallinder/go-randomdata v1.2.0 h1:DZ41wBchNRb/0GfsePLiSwb0PHZmT67XY00lCDlaYPg=
 github.com/Pallinder/go-randomdata v1.2.0/go.mod h1:yHmJgulpD2Nfrm0cR9tI/+oAgRqCQQixsA8HyRZfV9Y=
+github.com/apparentlymart/go-cidr v1.1.0 h1:2mAhrMoF+nhXqxTzSZMUzDHkLjmIHC+Zzn4tdgBZjnU=
+github.com/apparentlymart/go-cidr v1.1.0/go.mod h1:EBcsNrHc3zQeuaeCeCtQruQm+n9/YjEn/vI25Lg7Gwc=
 github.com/avast/retry-go v3.0.0+incompatible h1:4SOWQ7Qs+oroOTQOYnAHqelpCO0biHSxpiH9JdtuBj0=
 github.com/avast/retry-go v3.0.0+incompatible/go.mod h1:XtSnn+n/sHqQIpZ10K1qAevBhOOCWBLXXy3hyiqqBrY=
 github.com/awslabs/operatorpkg v0.0.0-20250804204931-57066b748e19 h1:2/SC5chiU6/x02f/aLQ6HLXM6LzV0cqGjnxio37dSLc=

--- a/pkg/cloudprovider/cloudprovider.go
+++ b/pkg/cloudprovider/cloudprovider.go
@@ -142,8 +142,9 @@ func (c CloudProvider) Create(ctx context.Context, nodeClaim *karpv1.NodeClaim) 
 	}
 
 	nc.Annotations = lo.Assign(nc.Annotations, map[string]string{
-		v1alpha1.AnnotationProxmoxNodeClassHash:        nodeClass.Hash(),
-		v1alpha1.AnnotationProxmoxNodeClassHashVersion: v1alpha1.ProxmoxNodeClassHashVersion,
+		v1alpha1.AnnotationProxmoxNodeClassHash:         nodeClass.Hash(),
+		v1alpha1.AnnotationProxmoxNodeClassHashVersion:  v1alpha1.ProxmoxNodeClassHashVersion,
+		v1alpha1.AnnotationProxmoxNodeInPlaceUpdateHash: nodeClass.InPlaceHash(),
 	})
 
 	return nc, nil

--- a/pkg/controllers/nodeclass/status/instancetemplate.go
+++ b/pkg/controllers/nodeclass/status/instancetemplate.go
@@ -70,6 +70,10 @@ func (i *InstanceTemplate) Reconcile(ctx context.Context, nodeClass *v1alpha1.Pr
 
 	for _, region := range i.cloudCapacityProvider.Regions() {
 		storage := i.cloudCapacityProvider.GetStorage(region, nodeClass.Spec.BootDevice.Storage)
+		if storage == nil {
+			continue
+		}
+
 		for _, z := range storage.Zones {
 			key := fmt.Sprintf("%s/%s/", region, z)
 

--- a/pkg/providers/instance/cloudinit/functions.go
+++ b/pkg/providers/instance/cloudinit/functions.go
@@ -21,10 +21,13 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"net"
 	"reflect"
 	"regexp"
 	"strings"
 	"text/template"
+
+	gocidr "github.com/apparentlymart/go-cidr/cidr"
 
 	goYaml "sigs.k8s.io/yaml/goyaml.v3"
 )
@@ -65,6 +68,10 @@ var genericMap = map[string]interface{}{
 	"contains":  func(substr string, str string) bool { return strings.Contains(str, substr) },
 	"hasPrefix": func(substr string, str string) bool { return strings.HasPrefix(str, substr) },
 	"hasSuffix": func(substr string, str string) bool { return strings.HasSuffix(str, substr) },
+
+	// Network functions:
+	"cidrhost":  cidrhost, // cidrhost "10.12.112.0/20" 16 -> 10.12.112.16
+	"cidrslaac": slaac,    // "2001:db8:1::/64" | slaac "00:1A:2B:3C:4D:5E" -> 2001:db8:1::21a:2bff:fe3c:4d5e
 }
 
 // ExecuteTemplate executes a template with the given data.
@@ -242,6 +249,57 @@ func base64decode(v string) (string, error) {
 	}
 
 	return string(data), nil
+}
+
+func cidrhost(cidr string, hostnum ...int) (string, error) {
+	ip, ipnet, err := net.ParseCIDR(cidr)
+	if err != nil {
+		return "", err
+	}
+
+	if len(hostnum) == 0 {
+		return ip.String(), nil
+	}
+
+	ip, err = gocidr.Host(ipnet, hostnum[0])
+	if err != nil {
+		return "", err
+	}
+
+	return ip.String(), nil
+}
+
+func slaac(mac string, cidr string) (string, error) {
+	_, ipnet, err := net.ParseCIDR(cidr)
+	if err != nil {
+		return "", err
+	}
+
+	hw, err := net.ParseMAC(mac)
+	if err != nil {
+		return "", err
+	}
+
+	ones, _ := ipnet.Mask.Size()
+	if ones > 112 {
+		return "", fmt.Errorf("slaac generator requires a mask of /64 to /112")
+	}
+
+	eui64 := net.IPv6zero
+	copy(eui64, ipnet.IP.To16())
+
+	copy(eui64[8:11], hw[0:3])
+	copy(eui64[13:16], hw[3:6])
+	eui64[11] = 0xFF
+	eui64[12] = 0xFE
+	eui64[8] ^= 0x02
+
+	l := ones / 8
+	for i := 15; i >= l; i-- {
+		ipnet.IP[i] = eui64[i]
+	}
+
+	return ipnet.String(), nil
 }
 
 func getValue(source string, key string) string {

--- a/pkg/providers/instance/cloudinit/functions_test.go
+++ b/pkg/providers/instance/cloudinit/functions_test.go
@@ -1,0 +1,69 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cloudinit
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFuncs(t *testing.T) {
+	tests := []struct {
+		name   string
+		tpl    string
+		expect string
+	}{
+		{
+			name:   "default",
+			tpl:    `ipv6: {{ "2001:db8:1::/64" | cidrslaac "00:1A:2B:3C:4D:5E" }}`,
+			expect: `ipv6: 2001:db8:1:0:21a:2bff:fe3c:4d5e/64`,
+		},
+		{
+			name:   "mask-80",
+			tpl:    `ipv6: {{ "2001:db8:1:2:3::/80" | cidrslaac "00:1A:2B:3C:4D:5E" }}`,
+			expect: `ipv6: 2001:db8:1:2:3:2bff:fe3c:4d5e/80`,
+		},
+		{
+			name:   "mask-88",
+			tpl:    `ipv6: {{ "2001:db8:1:2:3::/88" | cidrslaac "00:1A:2B:3C:4D:5E" }}`,
+			expect: `ipv6: 2001:db8:1:2:3:ff:fe3c:4d5e/88`,
+		},
+		{
+			name:   "mask-112",
+			tpl:    `ipv6: {{ "2001:db8:1:2:3::/112" | cidrslaac "00:1A:2B:3C:4D:5E" }}`,
+			expect: `ipv6: 2001:db8:1:2:3::4d5e/112`,
+		},
+		{
+			name:   "cidrhost",
+			tpl:    `ipv4: {{ "192.168.1.5/24" | cidrhost }}`,
+			expect: `ipv4: 192.168.1.5`,
+		},
+		{
+			name:   "cidrhost with host number",
+			tpl:    `ipv4: {{ cidrhost "192.168.1.5/24" 15 }}`,
+			expect: `ipv4: 192.168.1.15`,
+		},
+	}
+
+	for _, tt := range tests {
+		res, err := ExecuteTemplate(tt.tpl, nil)
+
+		assert.NoError(t, err)
+		assert.Equal(t, tt.expect, res, tt.name)
+	}
+}

--- a/pkg/providers/instance/cloudinit/types.go
+++ b/pkg/providers/instance/cloudinit/types.go
@@ -42,9 +42,16 @@ type InterfaceConfig struct {
 	MacAddr  string   `yaml:"mac_address,omitempty"`
 	DHCPv4   bool     `yaml:"dhcp4,omitempty"`
 	DHCPv6   bool     `yaml:"dhcp6,omitempty"`
+	SLAAC    bool     `yaml:"slaac,omitempty"`
 	Address4 []string `yaml:"addresses4,omitempty"`
 	Address6 []string `yaml:"addresses6,omitempty"`
 	Gateway4 string   `yaml:"gateway4,omitempty"`
 	Gateway6 string   `yaml:"gateway6,omitempty"`
 	MTU      uint32   `yaml:"mtu,omitempty"`
+
+	// Hypervisor specific fields
+	NodeAddress4 string `yaml:"node_address4,omitempty"`
+	NodeAddress6 string `yaml:"node_address6,omitempty"`
+	NodeGateway4 string `yaml:"node_gateway4,omitempty"`
+	NodeGateway6 string `yaml:"node_gateway6,omitempty"`
 }

--- a/pkg/providers/instance/cloudinit/utils_test.go
+++ b/pkg/providers/instance/cloudinit/utils_test.go
@@ -45,7 +45,7 @@ func TestGetNetworkConfigFromVirtualMachineConfig(t *testing.T) {
 				Net0:         "virtio=BC:24:11:CD:B9:41,bridge=vmbr0,firewall=1,mtu=1500",
 				Net1:         "virtio=BC:24:11:EE:9A:23,bridge=vmbr1,firewall=0,mtu=1400",
 				IPConfig0:    "ip=dhcp,ip6=auto",
-				IPConfig1:    "ip=1.2.3.4",
+				IPConfig1:    "ip=1.2.3.4/24",
 				Nameserver:   "1.1.1.1 2001:4860:4860::8888",
 				Searchdomain: "example.com",
 			},
@@ -55,11 +55,12 @@ func TestGetNetworkConfigFromVirtualMachineConfig(t *testing.T) {
 						Name:    "eth0",
 						MacAddr: "BC:24:11:CD:B9:41",
 						DHCPv4:  true,
+						SLAAC:   true,
 					},
 					{
 						Name:     "eth1",
 						MacAddr:  "BC:24:11:EE:9A:23",
-						Address4: []string{"1.2.3.4"},
+						Address4: []string{"1.2.3.4/24"},
 					},
 				},
 				NameServers:   []string{"1.1.1.1", "2001:4860:4860::8888"},
@@ -70,7 +71,7 @@ func TestGetNetworkConfigFromVirtualMachineConfig(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(fmt.Sprint(tt.name), func(t *testing.T) {
-			result := cloudinit.GetNetworkConfigFromVirtualMachineConfig(tt.template)
+			result := cloudinit.GetNetworkConfigFromVirtualMachineConfig(tt.template, nil)
 			assert.Equal(tt.network, result)
 		})
 	}


### PR DESCRIPTION
# Pull Request

## What? (description)

```go
	NodeAddress4 string `yaml:"node_address4,omitempty"`
	NodeAddress6 string `yaml:"node_address6,omitempty"`
	NodeGateway4 string `yaml:"node_gateway4,omitempty"`
	NodeGateway6 string `yaml:"node_gateway6,omitempty"`
```

These values are available in the network metadata templates. They make it possible to use the Proxmox host as a gateway for VMs, either for specific subnets or as the default gateway.

## Why? (reasoning)

part of #70

## Acceptance

Please use the following checklist:

- [ ] you linked an issue (if applicable)
- [ ] you included tests (if applicable)
- [ ] you linted your code (`make lint`)
- [ ] you linted your code (`make unit`)

> See `make help` for a description of the available targets.
