### PR TITLE
feat: simple ipam

### DIFF
--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -67,6 +67,7 @@ func main() {
 			op.InstanceProvider,
 			op.InstanceTemplateProvider,
 			op.CloudCapacityProvider,
+			op.NodeIpamController,
 		)...).
 		Start(ctx)
 }

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,8 @@ module github.com/sergelogvinov/karpenter-provider-proxmox
 
 go 1.25.1
 
+// replace github.com/sergelogvinov/go-proxmox => ../../proxmox/go-proxmox
+
 require (
 	github.com/apparentlymart/go-cidr v1.1.0
 	github.com/awslabs/operatorpkg v0.0.0-20250804204931-57066b748e19
@@ -10,7 +12,7 @@ require (
 	github.com/mitchellh/hashstructure/v2 v2.0.2
 	github.com/pkg/errors v0.9.1
 	github.com/samber/lo v1.51.0
-	github.com/sergelogvinov/go-proxmox v0.0.0-20250913072643-2097684ff6c8
+	github.com/sergelogvinov/go-proxmox v0.0.0-20250917044054-1af35c793934
 	github.com/spf13/cobra v1.10.1
 	github.com/stretchr/testify v1.11.1
 	go.uber.org/multierr v1.11.0
@@ -76,7 +78,7 @@ require (
 	golang.org/x/text v0.29.0 // indirect
 	golang.org/x/time v0.13.0 // indirect
 	gomodules.xyz/jsonpatch/v2 v2.5.0 // indirect
-	google.golang.org/protobuf v1.36.8 // indirect
+	google.golang.org/protobuf v1.36.9 // indirect
 	gopkg.in/evanphx/json-patch.v4 v4.13.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	k8s.io/apiextensions-apiserver v0.34.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -134,8 +134,8 @@ github.com/rogpeppe/go-internal v1.13.1/go.mod h1:uMEvuHeurkdAXX61udpOXGD/AzZDWN
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/samber/lo v1.51.0 h1:kysRYLbHy/MB7kQZf5DSN50JHmMsNEdeY24VzJFu7wI=
 github.com/samber/lo v1.51.0/go.mod h1:4+MXEGsJzbKGaUEQFKBq2xtfuznW9oz/WrgyzMzRoM0=
-github.com/sergelogvinov/go-proxmox v0.0.0-20250913072643-2097684ff6c8 h1:u27B32N+BkidDgR/3T90pPb5hzDUqM7YBjJtY7LhcOk=
-github.com/sergelogvinov/go-proxmox v0.0.0-20250913072643-2097684ff6c8/go.mod h1:vSTg/WC771SByc5087tu7uyGaXUv6fS8q3ak2X+xwqk=
+github.com/sergelogvinov/go-proxmox v0.0.0-20250917044054-1af35c793934 h1:s4a6OfXUMU7odq21KvsiW8TPqZOaaLj9krOVU0MEUgk=
+github.com/sergelogvinov/go-proxmox v0.0.0-20250917044054-1af35c793934/go.mod h1:vSTg/WC771SByc5087tu7uyGaXUv6fS8q3ak2X+xwqk=
 github.com/sirupsen/logrus v1.9.4-0.20230606125235-dd1b4c2e81af h1:Sp5TG9f7K39yfB+If0vjp97vuT74F72r8hfRpP8jLU0=
 github.com/sirupsen/logrus v1.9.4-0.20230606125235-dd1b4c2e81af/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVsIT4qYEQ=
 github.com/spf13/cobra v1.10.1 h1:lJeBwCfmrnXthfAupyUTzJ/J4Nc1RsHC/mSRU2dll/s=
@@ -212,8 +212,8 @@ golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8T
 golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 gomodules.xyz/jsonpatch/v2 v2.5.0 h1:JELs8RLM12qJGXU4u/TO3V25KW8GreMKl9pdkk14RM0=
 gomodules.xyz/jsonpatch/v2 v2.5.0/go.mod h1:AH3dM2RI6uoBZxn3LVrfvJ3E0/9dG4cSrbuBJT4moAY=
-google.golang.org/protobuf v1.36.8 h1:xHScyCOEuuwZEc6UtSOvPbAT4zRh0xcNRYekJwfqyMc=
-google.golang.org/protobuf v1.36.8/go.mod h1:fuxRtAxBytpl4zzqUh6/eyUujkJdNiuEkXntxiD/uRU=
+google.golang.org/protobuf v1.36.9 h1:w2gp2mA27hUeUzj9Ex9FBjsBm40zfaDtEWow293U7Iw=
+google.golang.org/protobuf v1.36.9/go.mod h1:fuxRtAxBytpl4zzqUh6/eyUujkJdNiuEkXntxiD/uRU=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntNwaWcugrBjAiHlqqRiVk=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EVd6muEfDQjcINNoR0C8j2r3qZ4Q=

--- a/pkg/controllers/controllers.go
+++ b/pkg/controllers/controllers.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/awslabs/operatorpkg/controller"
 
+	nodeipamctl "github.com/sergelogvinov/karpenter-provider-proxmox/pkg/controllers/node/ipam"
 	nodeclaiminplaceupdate "github.com/sergelogvinov/karpenter-provider-proxmox/pkg/controllers/nodeclaim/inplaceupdate"
 	nodeclaimlifecycle "github.com/sergelogvinov/karpenter-provider-proxmox/pkg/controllers/nodeclaim/lifecycle"
 	nodeclasshash "github.com/sergelogvinov/karpenter-provider-proxmox/pkg/controllers/nodeclass/hash"
@@ -35,6 +36,7 @@ import (
 	"github.com/sergelogvinov/karpenter-provider-proxmox/pkg/providers/cloudcapacity"
 	"github.com/sergelogvinov/karpenter-provider-proxmox/pkg/providers/instance"
 	"github.com/sergelogvinov/karpenter-provider-proxmox/pkg/providers/instancetemplate"
+	"github.com/sergelogvinov/karpenter-provider-proxmox/pkg/providers/nodeipam"
 
 	"k8s.io/utils/clock"
 
@@ -51,6 +53,7 @@ func NewControllers(ctx context.Context, mgr manager.Manager, clk clock.Clock,
 	instanceProvider instance.Provider,
 	instanceTemplateProvider instancetemplate.Provider,
 	cloudCapacityProvider cloudcapacity.Provider,
+	nodeIpamProvider nodeipam.Provider,
 ) []controller.Controller {
 	controllers := []controller.Controller{
 		nodeclaiminplaceupdate.NewController(kubeClient, instanceProvider),
@@ -63,6 +66,7 @@ func NewControllers(ctx context.Context, mgr manager.Manager, clk clock.Clock,
 		nodetemplateunmanagedclassstatus.NewController(kubeClient, instanceTemplateProvider),
 		cloudcapacitynode.NewController(cloudCapacityProvider),
 		cloudcapacitynodeload.NewController(cloudCapacityProvider),
+		nodeipamctl.NewController(kubeClient, nodeIpamProvider),
 	}
 
 	return controllers

--- a/pkg/controllers/node/ipam/controller.go
+++ b/pkg/controllers/node/ipam/controller.go
@@ -1,0 +1,83 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package ipam
+
+import (
+	"context"
+	"time"
+
+	"github.com/awslabs/operatorpkg/reasonable"
+
+	"github.com/sergelogvinov/karpenter-provider-proxmox/pkg/providers/nodeipam"
+
+	corev1 "k8s.io/api/core/v1"
+
+	controllerruntime "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+const templateRepeatPeriod = 10 * time.Second
+
+// Controller reconciles an ProxmoxNodeClass object to update its status
+type Controller struct {
+	kubeClient       client.Client
+	nodeIpamProvider nodeipam.Provider
+}
+
+// NewController constructs a controller instance
+func NewController(kubeClient client.Client, nodeIpamProvider nodeipam.Provider) *Controller {
+	return &Controller{
+		kubeClient:       kubeClient,
+		nodeIpamProvider: nodeIpamProvider,
+	}
+}
+
+func (c *Controller) Name() string {
+	return "node.ipam"
+}
+
+// Reconcile executes a control loop for the resource
+func (c *Controller) Reconcile(ctx context.Context, n *corev1.Node) (reconcile.Result, error) {
+	if !n.GetDeletionTimestamp().IsZero() {
+		c.nodeIpamProvider.ReleaseNodeIPs(n)
+
+		return reconcile.Result{}, nil
+	}
+
+	err := c.nodeIpamProvider.OccupyNodeIPs(n)
+	if err != nil {
+		return reconcile.Result{RequeueAfter: templateRepeatPeriod}, err
+	}
+
+	return reconcile.Result{}, nil
+}
+
+// Register registers the controller with the manager
+func (c *Controller) Register(_ context.Context, m manager.Manager) error {
+	return controllerruntime.NewControllerManagedBy(m).
+		Named(c.Name()).
+		For(&corev1.Node{}, builder.WithPredicates(ipChangedPredicate{})).
+		WithOptions(controller.Options{
+			RateLimiter:             reasonable.RateLimiter(),
+			MaxConcurrentReconciles: 10,
+		}).
+		Complete(reconcile.AsReconciler(m.GetClient(), c))
+}

--- a/pkg/controllers/node/ipam/predicates.go
+++ b/pkg/controllers/node/ipam/predicates.go
@@ -1,0 +1,54 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package ipam
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/equality"
+
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+)
+
+type ipChangedPredicate struct {
+	predicate.Funcs
+}
+
+var _ predicate.Predicate = ipChangedPredicate{}
+
+func (p ipChangedPredicate) Delete(e event.DeleteEvent) bool {
+	return false
+}
+
+func (p ipChangedPredicate) Update(e event.UpdateEvent) bool {
+	if e.ObjectOld == nil || e.ObjectNew == nil {
+		return false
+	}
+
+	typedOld, ok := e.ObjectOld.(*corev1.Node)
+	if !ok {
+		return false
+	}
+
+	typedNew, ok := e.ObjectNew.(*corev1.Node)
+	if !ok {
+		return false
+	}
+
+	return !equality.Semantic.DeepEqual(typedOld.Status.Addresses, typedNew.Status.Addresses) ||
+		typedOld.ObjectMeta.DeletionTimestamp != typedNew.ObjectMeta.DeletionTimestamp
+}

--- a/pkg/controllers/nodeclass/status/metadataoptions.go
+++ b/pkg/controllers/nodeclass/status/metadataoptions.go
@@ -49,22 +49,22 @@ func (i *MetadataOptions) Reconcile(ctx context.Context, nodeClass *v1alpha1.Pro
 
 			return reconcile.Result{}, fmt.Errorf("metadataOptions.TemplatesRef is required when metadataOptions.Type is 'cdrom'")
 		}
-	}
 
-	secret := &corev1.Secret{}
-	secretKey := client.ObjectKey{
-		Name:      nodeClass.Spec.MetadataOptions.TemplatesRef.Name,
-		Namespace: nodeClass.Spec.MetadataOptions.TemplatesRef.Namespace,
-	}
-
-	if err := i.kubeClient.Get(ctx, secretKey, secret); err != nil {
-		if apierrors.IsNotFound(err) {
-			nodeClass.StatusConditions().SetFalse(v1alpha1.ConditionInstanceMetadataOptionsReady, "MetadataOptionsNotFound", "Metadata secret resource not found")
-
-			return reconcile.Result{RequeueAfter: metadataScanPeriod}, nil
+		secret := &corev1.Secret{}
+		secretKey := client.ObjectKey{
+			Name:      nodeClass.Spec.MetadataOptions.TemplatesRef.Name,
+			Namespace: nodeClass.Spec.MetadataOptions.TemplatesRef.Namespace,
 		}
 
-		return reconcile.Result{}, err
+		if err := i.kubeClient.Get(ctx, secretKey, secret); err != nil {
+			if apierrors.IsNotFound(err) {
+				nodeClass.StatusConditions().SetFalse(v1alpha1.ConditionInstanceMetadataOptionsReady, "MetadataOptionsNotFound", "Metadata TemplatesRef secret resource not found")
+
+				return reconcile.Result{RequeueAfter: metadataScanPeriod}, nil
+			}
+
+			return reconcile.Result{}, err
+		}
 	}
 
 	nodeClass.StatusConditions().SetTrue(v1alpha1.ConditionInstanceMetadataOptionsReady)

--- a/pkg/providers/instance/instance_network.go
+++ b/pkg/providers/instance/instance_network.go
@@ -1,0 +1,145 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package instance
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"strings"
+
+	"github.com/sergelogvinov/karpenter-provider-proxmox/pkg/providers/cloudcapacity"
+	"github.com/sergelogvinov/karpenter-provider-proxmox/pkg/providers/instance/cloudinit"
+	utilsip "github.com/sergelogvinov/karpenter-provider-proxmox/pkg/utils/ip"
+)
+
+func (p *DefaultProvider) instanceNetworkSetup(
+	ctx context.Context,
+	region string,
+	zone string,
+	vmID int,
+) error {
+	px, err := p.cluster.GetProxmoxCluster(region)
+	if err != nil {
+		return fmt.Errorf("failed to get proxmox cluster with region name %s: %v", region, err)
+	}
+
+	vm, err := px.GetVMConfig(ctx, vmID)
+	if err != nil {
+		return fmt.Errorf("failed to get vm config for vm %d in region %s: %v", vmID, region, err)
+	}
+
+	ifaces := map[string]cloudcapacity.NetworkIfaceInfo{}
+
+	net := p.cloudCapacityProvider.GetNetwork(region, zone)
+	if net != nil {
+		ifaces = net.Ifaces
+	}
+
+	networkValues := cloudinit.GetNetworkConfigFromVirtualMachineConfig(vm.VirtualMachineConfig, ifaces)
+	if err = p.generateNetworkIPs(&networkValues); err != nil {
+		return fmt.Errorf("failed to generate network IPs: %v", err)
+	}
+
+	if err = cloudinit.SetNetworkConfig(ctx, vm, networkValues); err != nil {
+		return fmt.Errorf("failed to update network config: %v", err)
+	}
+
+	vm.VirtualMachineConfig.MergeIDEs()
+
+	for _, iso := range vm.VirtualMachineConfig.IDEs {
+		if strings.Contains(iso, "cloudinit") {
+			if err = px.RegenerateVMCloudInit(ctx, vm.Node, vmID); err != nil {
+				return fmt.Errorf("failed to regenerate cloudinit iso for vm %d in region %s: %v", vmID, region, err)
+			}
+
+			break
+		}
+	}
+
+	return nil
+}
+
+func (p *DefaultProvider) generateNetworkIPs(networkConfig *cloudinit.NetworkConfig) error {
+	for i := range networkConfig.Interfaces {
+		iface := &networkConfig.Interfaces[i]
+
+		if len(iface.Address4) > 0 {
+			addresses := []string{}
+
+			for _, addr := range iface.Address4 {
+				ipv4, ipnet, err := net.ParseCIDR(addr)
+				if err != nil {
+					return err
+				}
+
+				if ipv4.Equal(ipnet.IP) {
+					err = p.nodeIpamProvider.AllocateOrOccupyCIDR(addr)
+					if err != nil {
+						return err
+					}
+
+					subnet := ipnet.String()
+
+					if iface.NodeAddress4 != "" {
+						nodeip, nodenet, err := net.ParseCIDR(iface.NodeAddress4)
+						if err != nil {
+							return err
+						}
+
+						if ipnet.Contains(nodenet.IP) {
+							nodenet.IP = nodeip
+							subnet = nodenet.String()
+						}
+					}
+
+					ip, err := p.nodeIpamProvider.OccupyIP(subnet)
+					if err != nil {
+						return err
+					}
+
+					ipnet.IP = ip
+					addresses = append(addresses, ipnet.String())
+				}
+			}
+
+			iface.Address4 = addresses
+		}
+
+		if len(iface.Address6) > 0 {
+			addresses := []string{}
+
+			for _, addr := range iface.Address6 {
+				ipv6, ipnet, err := net.ParseCIDR(addr)
+				if err != nil {
+					return err
+				}
+
+				if ipv6.Equal(ipnet.IP) {
+					ipv6, err := utilsip.Slaac(iface.MacAddr, addr)
+					if err == nil {
+						addresses = append(addresses, ipv6)
+					}
+				}
+			}
+
+			iface.Address6 = addresses
+		}
+	}
+
+	return nil
+}

--- a/pkg/providers/nodeipam/doc.go
+++ b/pkg/providers/nodeipam/doc.go
@@ -1,0 +1,18 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package nodeipam provides an IP address management controller for Kubernetes nodes (Proxmox Virtual Machine).
+package nodeipam

--- a/pkg/providers/nodeipam/ipam/doc.go
+++ b/pkg/providers/nodeipam/ipam/doc.go
@@ -1,0 +1,19 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package ipam provides an interface for managing IP address allocation and
+// deallocation for IPs in a subnet.
+package ipam

--- a/pkg/providers/nodeipam/ipam/ippool.go
+++ b/pkg/providers/nodeipam/ipam/ippool.go
@@ -1,0 +1,192 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package ipam
+
+import (
+	"errors"
+	"fmt"
+	"math/big"
+	"net"
+	"sync"
+
+	gocidr "github.com/apparentlymart/go-cidr/cidr"
+)
+
+type IPPool struct {
+	sync.RWMutex
+
+	// IPNet is the IP network for the pool.
+	IPNet *net.IPNet
+	// maxIPs is the maximum number of IPs that can be allocated in the pool.
+	maxIPs int
+	// pool holds the allocated IPs bits in the pool.
+	pool big.Int
+}
+
+func ParseCIDR(s string) (*IPPool, error) {
+	var maxIPs int
+
+	_, ipNet, err := net.ParseCIDR(s)
+	if err != nil {
+		return nil, errors.New("Invalid CIDR format")
+	}
+
+	ones, bits := ipNet.Mask.Size()
+
+	switch bits {
+	case 32:
+		maxIPs = 1 << (int(32) - ones)
+	case 128:
+		maxIPs = 1 << (int(128) - ones)
+	default:
+		return nil, errors.New("Only IPv4 and IPv6 are supported")
+	}
+
+	maxIPs -= 1 // Exclude network address for IP allocation
+
+	return &IPPool{IPNet: ipNet, maxIPs: maxIPs}, nil
+}
+
+func (p *IPPool) IsEmpty() bool {
+	p.RLock()
+	defer p.RUnlock()
+
+	return p.pool.BitLen() == 0
+}
+
+func (p *IPPool) Size() int {
+	p.RLock()
+	defer p.RUnlock()
+
+	size := 0
+
+	for i := 0; i <= p.maxIPs; i++ {
+		if p.pool.Bit(i) == 1 {
+			size++
+		}
+	}
+
+	return size
+}
+
+func (p *IPPool) EqualCIDR(other *net.IPNet) bool {
+	return p.IPNet.IP.Equal(other.IP) && (p.IPNet.Mask.String() == other.Mask.String())
+}
+
+func (p *IPPool) String() string {
+	return fmt.Sprintf("CIDR: %s used-map: %s, total: %d", p.IPNet.String(), p.pool.Text(2), p.maxIPs)
+}
+
+func (p *IPPool) Contains(ip net.IP) bool {
+	return p.IPNet.Contains(ip)
+}
+
+func (p *IPPool) ContainsCIDR(ip *net.IPNet) bool {
+	return p.IPNet.Contains(ip.IP)
+}
+
+func (p *IPPool) Occupy(ip net.IP) bool {
+	p.Lock()
+	defer p.Unlock()
+
+	if p.IPNet.IP.Equal(ip) {
+		return false
+	}
+
+	inx, err := p.HostIndex(ip)
+	if err != nil {
+		return false
+	}
+
+	if p.pool.Bit(inx) == 0 {
+		p.pool.SetBit(&p.pool, inx, 1)
+
+		return true
+	}
+
+	return false
+}
+
+func (p *IPPool) Next(cidr ...*net.IPNet) net.IP {
+	p.Lock()
+	defer p.Unlock()
+
+	var (
+		candidate int
+		err       error
+	)
+
+	if len(cidr) > 0 && !p.IPNet.IP.Equal(cidr[0].IP) {
+		candidate, err = p.HostIndex(cidr[0].IP)
+		if err != nil {
+			candidate = 0
+		}
+	}
+
+	for range p.maxIPs {
+		if p.pool.Bit(candidate) == 0 {
+			break
+		}
+
+		candidate = (candidate + 1) % p.maxIPs
+	}
+
+	p.pool.SetBit(&p.pool, candidate, 1)
+
+	ip, err := gocidr.Host(p.IPNet, candidate+1)
+	if err != nil {
+		return nil
+	}
+
+	return ip
+}
+
+func (p *IPPool) Release(ip net.IP) error {
+	p.Lock()
+	defer p.Unlock()
+
+	if p.IPNet.IP.Equal(ip) {
+		return nil
+	}
+
+	inx, err := p.HostIndex(ip)
+	if err != nil {
+		return err
+	}
+
+	if p.pool.Bit(inx) == 1 {
+		p.pool.SetBit(&p.pool, inx, 0)
+	}
+
+	return nil
+}
+
+func (p *IPPool) HostIndex(ip net.IP) (int, error) {
+	if !p.IPNet.Contains(ip) {
+		return -1, fmt.Errorf("IP %s is not in the CIDR %s", ip.String(), p.IPNet.String())
+	}
+
+	c := big.NewInt(0).SetBytes(ip.To16())
+	b := big.NewInt(0).SetBytes(p.IPNet.IP.To16())
+
+	index := big.NewInt(0).Sub(c, b)
+	if index.Int64() > int64(p.maxIPs) {
+		return -1, fmt.Errorf("IP %s index %d is out of range for CIDR %s", ip.String(), index.Int64(), p.IPNet.String())
+	}
+
+	return int(index.Int64() - 1), nil
+}

--- a/pkg/providers/nodeipam/ipam/ippool_test.go
+++ b/pkg/providers/nodeipam/ipam/ippool_test.go
@@ -1,0 +1,265 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package ipam_test
+
+import (
+	"net"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/sergelogvinov/karpenter-provider-proxmox/pkg/providers/nodeipam/ipam"
+)
+
+func TestParseCIDR(t *testing.T) {
+	tests := []struct {
+		name   string
+		cidr   string
+		expect string
+	}{
+		{
+			name:   "IPv4",
+			cidr:   "192.168.1.0/24",
+			expect: "CIDR: 192.168.1.0/24 used-map: 0, total: 255",
+		},
+		{
+			name:   "IPv6",
+			cidr:   "2a01:4f8:10:20::/96",
+			expect: "CIDR: 2a01:4f8:10:20::/96 used-map: 0, total: 4294967295",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ipPool, err := ipam.ParseCIDR(tt.cidr)
+			assert.NoError(t, err)
+			assert.Equal(t, tt.expect, ipPool.String())
+		})
+	}
+}
+
+func TestContains(t *testing.T) {
+	tests := []struct {
+		name   string
+		cidr   string
+		ip     string
+		expect bool
+	}{
+		{
+			name:   "IPv4",
+			cidr:   "192.168.1.0/24",
+			ip:     "192.168.1.2",
+			expect: true,
+		},
+		{
+			name:   "IPv4-outside",
+			cidr:   "192.168.1.0/24",
+			ip:     "192.168.2.1",
+			expect: false,
+		},
+		{
+			name:   "IPv6",
+			cidr:   "2a01:4f8:10:20::/96",
+			ip:     "2a01:4f8:10:20::1",
+			expect: true,
+		},
+		{
+			name:   "IPv6-outside",
+			cidr:   "2a01:4f8:10:20:30::/96",
+			ip:     "2a01:4f8:10:20:30:40::ff01",
+			expect: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ipPool, err := ipam.ParseCIDR(tt.cidr)
+			assert.NoError(t, err)
+
+			assert.Equal(t, tt.expect, ipPool.Contains(net.ParseIP(tt.ip)))
+		})
+	}
+}
+
+func TestOccupy(t *testing.T) {
+	tests := []struct {
+		name   string
+		cidr   string
+		occupy []string
+		expect string
+	}{
+		{
+			name:   "IPv4",
+			cidr:   "192.168.1.0/24",
+			occupy: []string{"192.168.1.1", "192.168.1.2", "192.168.1.7"},
+			expect: "CIDR: 192.168.1.0/24 used-map: 1000011, total: 255",
+		},
+		{
+			name:   "IPv4-22",
+			cidr:   "192.168.1.22/24",
+			occupy: []string{"192.168.1.1", "192.168.1.3", "192.168.1.7"},
+			expect: "CIDR: 192.168.1.0/24 used-map: 1000101, total: 255",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ipPool, err := ipam.ParseCIDR(tt.cidr)
+			assert.NoError(t, err)
+
+			for _, ip := range tt.occupy {
+				ok := ipPool.Occupy(net.ParseIP(ip))
+				assert.True(t, ok)
+			}
+
+			assert.Equal(t, tt.expect, ipPool.String())
+		})
+	}
+}
+
+func TestNext(t *testing.T) {
+	tests := []struct {
+		name   string
+		cidr   string
+		expect string
+	}{
+		{
+			name:   "IPv4",
+			cidr:   "192.168.1.0/24",
+			expect: "192.168.1.1",
+		},
+		{
+			name:   "IPv4-22",
+			cidr:   "192.168.1.22/24",
+			expect: "192.168.1.23",
+		},
+		{
+			name:   "IPv6",
+			cidr:   "2a01:4f8:10:20::/96",
+			expect: "2a01:4f8:10:20::1",
+		},
+		{
+			name:   "IPv6-112",
+			cidr:   "2a01:4f8:10:20::ff80/112",
+			expect: "2a01:4f8:10:20::ff81",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ipPool, err := ipam.ParseCIDR(tt.cidr)
+			assert.NoError(t, err)
+
+			ip, ipNet, err := net.ParseCIDR(tt.cidr)
+			assert.NoError(t, err)
+			ipPool.Occupy(ip)
+
+			ipNet.IP = ip
+
+			assert.Equal(t, tt.expect, ipPool.Next(ipNet).String())
+		})
+	}
+}
+
+func TestRelease(t *testing.T) {
+	tests := []struct {
+		name   string
+		cidr   string
+		expect string
+	}{
+		{
+			name:   "IPv4",
+			cidr:   "192.168.1.0/24",
+			expect: "CIDR: 192.168.1.0/24 used-map: 0, total: 255",
+		},
+		{
+			name:   "IPv4-22",
+			cidr:   "192.168.1.22/24",
+			expect: "CIDR: 192.168.1.0/24 used-map: 0, total: 255",
+		},
+		{
+			name:   "IPv6",
+			cidr:   "2a01:4f8:10:20::/96",
+			expect: "CIDR: 2a01:4f8:10:20::/96 used-map: 0, total: 4294967295",
+		},
+		{
+			name:   "IPv6-112",
+			cidr:   "2a01:4f8:10:20::ff80/112",
+			expect: "CIDR: 2a01:4f8:10:20::/112 used-map: 0, total: 65535",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ipPool, err := ipam.ParseCIDR(tt.cidr)
+			assert.NoError(t, err)
+
+			ip, _, err := net.ParseCIDR(tt.cidr)
+			assert.NoError(t, err)
+			ipPool.Occupy(ip)
+
+			assert.NoError(t, ipPool.Release(ip))
+			assert.Equal(t, tt.expect, ipPool.String())
+		})
+	}
+}
+
+func TestHostIndex(t *testing.T) {
+	tests := []struct {
+		name      string
+		cidr      string
+		host      string
+		expect    int
+		expectErr bool
+	}{
+		{
+			name:   "IPv4",
+			cidr:   "192.168.1.0/24",
+			host:   "192.168.1.2",
+			expect: 1,
+		},
+		{
+			name:      "IPv4-outside",
+			cidr:      "192.168.1.0/24",
+			host:      "192.168.2.1",
+			expect:    0,
+			expectErr: true,
+		},
+		{
+			name:   "IPv6",
+			cidr:   "2a01:4f8:10a:2f45::/96",
+			host:   "2a01:4f8:10a:2f45::1",
+			expect: 0,
+		},
+		{
+			name:   "IPv6-255",
+			cidr:   "2a01:4f8:10a:2f45::/96",
+			host:   "2a01:4f8:10a:2f45::ff",
+			expect: 254,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ipPool, err := ipam.ParseCIDR(tt.cidr)
+			assert.NoError(t, err)
+
+			i, err := ipPool.HostIndex(net.ParseIP(tt.host))
+			if tt.expectErr {
+				assert.Error(t, err)
+				return
+			}
+
+			assert.NoError(t, err)
+			assert.Equal(t, tt.expect, i)
+		})
+	}
+}

--- a/pkg/providers/nodeipam/nodeipam.go
+++ b/pkg/providers/nodeipam/nodeipam.go
@@ -1,0 +1,245 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package nodeipam
+
+import (
+	"context"
+	"fmt"
+	"net"
+
+	"github.com/sergelogvinov/karpenter-provider-proxmox/pkg/providers/cloudcapacity"
+	ipam "github.com/sergelogvinov/karpenter-provider-proxmox/pkg/providers/nodeipam/ipam"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/kubernetes"
+)
+
+type Provider interface {
+	UpdateNodeCIDR(ctx context.Context) error
+	AllocateOrOccupyCIDR(subnet string) error
+	ReleaseCIDR(subnet string) error
+
+	OccupyNodeIPs(node *corev1.Node) error
+	OccupyIP(subnet string) (net.IP, error)
+	ReleaseNodeIPs(node *corev1.Node) error
+	ReleaseIP(ip string) error
+
+	String() string
+}
+
+// DefaultProvider is the provider that manages node ipam state.
+type DefaultProvider struct {
+	kubeClient            kubernetes.Interface
+	cloudCapacityProvider cloudcapacity.Provider
+
+	// proxmoxZoneCIDRMask []int
+	subnets []*ipam.IPPool
+}
+
+func NewDefaultProvider(
+	ctx context.Context,
+	kubeClient kubernetes.Interface,
+	cloudCapacityProvider cloudcapacity.Provider,
+) *DefaultProvider {
+	return &DefaultProvider{
+		kubeClient:            kubeClient,
+		cloudCapacityProvider: cloudCapacityProvider,
+	}
+}
+
+func (p *DefaultProvider) UpdateNodeCIDR(ctx context.Context) error {
+	for _, region := range p.cloudCapacityProvider.Regions() {
+		for _, zones := range p.cloudCapacityProvider.Zones(region) {
+			n := p.cloudCapacityProvider.GetNetwork(region, zones)
+			if n == nil {
+				continue
+			}
+
+			for _, iface := range n.Ifaces {
+				if iface.Address4 != "" {
+					p.AllocateOrOccupyCIDR(iface.Address4)
+				}
+
+				if iface.Gateway4 != "" {
+					for i := range p.subnets {
+						if p.subnets[i] == nil {
+							continue
+						}
+
+						ip := net.ParseIP(iface.Gateway4)
+						if p.subnets[i].Contains(ip) {
+							p.subnets[i].Occupy(ip)
+						}
+					}
+				}
+			}
+		}
+	}
+
+	return nil
+}
+
+func (p *DefaultProvider) AllocateOrOccupyCIDR(subnet string) error {
+	ip, cidr, err := net.ParseCIDR(subnet)
+	if err != nil {
+		return err
+	}
+
+	if cidr.IP.To4() == nil {
+		return fmt.Errorf("only IPv4 is supported")
+	}
+
+	var ipPool *ipam.IPPool
+
+	for i := range p.subnets {
+		if p.subnets[i] == nil {
+			continue
+		}
+
+		if p.subnets[i].ContainsCIDR(cidr) {
+			ipPool = p.subnets[i]
+
+			break
+		}
+	}
+
+	if ipPool == nil {
+		ipPool, err = ipam.ParseCIDR(subnet)
+		if err != nil {
+			return err
+		}
+
+		p.subnets = append(p.subnets, ipPool)
+	}
+
+	if !ip.Equal(cidr.IP) {
+		ipPool.Occupy(ip)
+	}
+
+	return nil
+}
+
+func (p *DefaultProvider) ReleaseCIDR(subnet string) error {
+	_, cidr, err := net.ParseCIDR(subnet)
+	if err != nil {
+		return err
+	}
+
+	for i := range p.subnets {
+		if p.subnets[i] == nil {
+			continue
+		}
+
+		if p.subnets[i].EqualCIDR(cidr) {
+			p.subnets = append(p.subnets[:i], p.subnets[i+1:]...)
+
+			return nil
+		}
+	}
+
+	return nil
+}
+
+func (p *DefaultProvider) OccupyNodeIPs(node *corev1.Node) error {
+	if len(p.subnets) == 0 {
+		return fmt.Errorf("no subnets available for IPAM")
+	}
+
+	return p.updateNodeIPs(node, func(subnet *ipam.IPPool, ip net.IP) error {
+		subnet.Occupy(ip)
+
+		return nil
+	})
+}
+
+func (s *DefaultProvider) OccupyIP(subnet string) (net.IP, error) {
+	ip, cidr, err := net.ParseCIDR(subnet)
+	if err != nil {
+		return nil, err
+	}
+
+	cidr.IP = ip
+
+	for i := range s.subnets {
+		if s.subnets[i] == nil {
+			continue
+		}
+
+		if s.subnets[i].ContainsCIDR(cidr) {
+			ip := s.subnets[i].Next(cidr)
+			if ip == nil {
+				return nil, fmt.Errorf("no available IPs in subnet %s", cidr.String())
+			}
+
+			return ip, nil
+		}
+	}
+
+	return nil, fmt.Errorf("no subnet found for cidr %s", cidr.String())
+}
+
+func (p *DefaultProvider) ReleaseNodeIPs(node *corev1.Node) error {
+	if len(p.subnets) == 0 {
+		return fmt.Errorf("no subnets available for IPAM")
+	}
+
+	return p.updateNodeIPs(node, func(subnet *ipam.IPPool, ip net.IP) error {
+		return subnet.Release(ip)
+	})
+}
+
+func (p *DefaultProvider) ReleaseIP(ip string) error {
+	return nil
+}
+
+func (p *DefaultProvider) String() string {
+	capacity := make([]string, len(p.subnets))
+	for i := range p.subnets {
+		if p.subnets[i] != nil {
+			capacity[i] = p.subnets[i].String()
+		}
+	}
+
+	return fmt.Sprintf("NodeIpamProvider{subnets: %d, capacity: %v}", len(p.subnets), capacity)
+}
+
+func (p *DefaultProvider) updateNodeIPs(node *corev1.Node, f func(subnet *ipam.IPPool, ip net.IP) error) error {
+	for _, addr := range node.Status.Addresses {
+		if addr.Type != corev1.NodeInternalIP && addr.Type != corev1.NodeExternalIP {
+			continue
+		}
+
+		ip := net.ParseIP(addr.Address)
+		if ip == nil || ip.To4() == nil {
+			continue
+		}
+
+		for i := range p.subnets {
+			if p.subnets[i] == nil {
+				continue
+			}
+
+			if p.subnets[i].Contains(ip) {
+				if err := f(p.subnets[i], ip); err != nil {
+					return err
+				}
+			}
+		}
+	}
+
+	return nil
+}

--- a/pkg/utils/ip/ip.go
+++ b/pkg/utils/ip/ip.go
@@ -1,0 +1,77 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package ip
+
+import (
+	"fmt"
+	"net"
+
+	gocidr "github.com/apparentlymart/go-cidr/cidr"
+)
+
+// CIDRHost returns the IP address of the given host number in the given CIDR.
+func CIDRHost(cidr string, hostnum ...int) (string, error) {
+	ip, ipnet, err := net.ParseCIDR(cidr)
+	if err != nil {
+		return "", err
+	}
+
+	if len(hostnum) == 0 {
+		return ip.String(), nil
+	}
+
+	ip, err = gocidr.Host(ipnet, hostnum[0])
+	if err != nil {
+		return "", err
+	}
+
+	return ip.String(), nil
+}
+
+// Slaac returns the SLAAC address for the given MAC address in the given IPv6 CIDR.
+func Slaac(mac string, cidr string) (string, error) {
+	_, ipnet, err := net.ParseCIDR(cidr)
+	if err != nil {
+		return "", err
+	}
+
+	hw, err := net.ParseMAC(mac)
+	if err != nil {
+		return "", err
+	}
+
+	ones, _ := ipnet.Mask.Size()
+	if ones > 112 {
+		return "", fmt.Errorf("slaac generator requires a mask of /64 to /112")
+	}
+
+	eui64 := net.IPv6zero
+	copy(eui64, ipnet.IP.To16())
+
+	copy(eui64[8:11], hw[0:3])
+	copy(eui64[13:16], hw[3:6])
+	eui64[11] = 0xFF
+	eui64[12] = 0xFE
+	eui64[8] ^= 0x02
+
+	l := ones / 8
+	for i := 15; i >= l; i-- {
+		ipnet.IP[i] = eui64[i]
+	}
+
+	return ipnet.String(), nil
+}


### PR DESCRIPTION
# Pull Request

## What? (description)

Simple IPAM Implementation

The IPAM logic is entirely based on the `ipconfig` virtual machine template parameters.
If an IPv4 or IPv6 subnet is defined, the provider will allocate addresses from that subnet.

* IPv4 allocation - it collects all existing IPs across the cluster and Proxmox node bridges, then assigns a new IP while resolving any conflicts.
* IPv6 allocation - it uses SLAAC  to generate IPv6 addresses, even when the network prefix is smaller than /64.

## Why? (reasoning)

#70 

## Acceptance

Please use the following checklist:

- [ ] you linked an issue (if applicable)
- [ ] you included tests (if applicable)
- [ ] you linted your code (`make lint`)
- [ ] you linted your code (`make unit`)

> See `make help` for a description of the available targets.
