### PR TITLE
fix: set default gateway as cidr

### DIFF
--- a/pkg/providers/instance/cloudinit/network.go
+++ b/pkg/providers/instance/cloudinit/network.go
@@ -97,11 +97,11 @@ config:
 {{- if or $iface.Gateway4 $iface.Gateway6 }}
       routes:
 {{- if $iface.Gateway4 }}
-      - to: default
+      - to: "0.0.0.0/0"
         via: {{ $iface.Gateway4 | quote }}
 {{- end }}
 {{- if $iface.Gateway6 }}
-      - to: default
+      - to: "::/0"
         via: {{ $iface.Gateway6 | quote }}
 {{- end }}
 {{- end }}
@@ -109,7 +109,7 @@ config:
       addresses:
       - {{ $iface.NodeAddress6 | cidrslaac $iface.MacAddr | quote }}
       routes:
-      - to: default
+      - to: "::/0"
         via: {{ $iface.NodeAddress6 | cidrhost | quote }}
   {{- end }}
 {{- end }}

--- a/pkg/providers/instance/cloudinit/network_test.go
+++ b/pkg/providers/instance/cloudinit/network_test.go
@@ -242,9 +242,9 @@ func TestDefaultNetworkV2(t *testing.T) {
       - "192.168.1.100/24"
       - "2000:db8::5/64"
       routes:
-      - to: default
+      - to: "0.0.0.0/0"
         via: "192.168.1.1"
-      - to: default
+      - to: "::/0"
         via: "2000:db8::1"
       nameservers:
         addresses:
@@ -351,7 +351,7 @@ func TestDefaultNetworkV2(t *testing.T) {
       addresses:
       - "2001:db8:1:0:211:22ff:fe33:4455/64"
       routes:
-      - to: default
+      - to: "::/0"
         via: "2001:db8:1::128"
       nameservers:
         addresses:


### PR DESCRIPTION
According to the documentation, the default gateway can be set using the string "default". However, some operating systems may not support this value and require an explicit IP address instead.

# Pull Request

## What? (description)

## Why? (reasoning)

https://github.com/siderolabs/talos/pull/11886

## Acceptance

Please use the following checklist:

- [ ] you linked an issue (if applicable)
- [ ] you included tests (if applicable)
- [ ] you linted your code (`make lint`)
- [ ] you linted your code (`make unit`)

> See `make help` for a description of the available targets.
