### PR TITLE
fix(proxmox): continue node scanning even if some nodes are inaccessible

### DIFF
--- a/pkg/providers/cloudcapacity/cloudcapacity.go
+++ b/pkg/providers/cloudcapacity/cloudcapacity.go
@@ -187,7 +187,8 @@ func (p *DefaultProvider) UpdateNodeCapacity(ctx context.Context) error {
 
 			node, err := cl.Node(ctx, item.Node)
 			if err != nil {
-				return fmt.Errorf("cannot find node with name %s in region %s: %w", item.Node, region, err)
+				log.Error(err, "Failed to find node in region", "node", item.Node, "region", region)
+				continue
 			}
 
 			key := fmt.Sprintf("%s/%s", region, item.Node)


### PR DESCRIPTION
## Summary
This PR fixes an issue where the node scanning logic aborted when encountering an inaccessible node.  
Instead of failing the entire process, the provider now **skips inaccessible nodes** and continues scanning the rest.  

## Issue
Fixes #100 

## Changes
- Updated node scanning logic to continue on error instead of returning immediately.
- Adjusted logging to report skipped nodes without breaking the workflow.

## Testing
- Verified with a cluster where the Proxmox user has access to only a subset of nodes.
- Confirmed that accessible nodes are correctly discovered and provisioned.
- Inaccessible nodes are logged and skipped without causing failures.

## Impact
This change improves robustness in multi-node clusters where RBAC or network restrictions prevent access to all nodes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved resilience of capacity updates: when individual nodes can’t be located during an update, the system now logs the problem and continues processing remaining nodes instead of aborting the whole operation. This reduces failed runs in environments with transient or decommissioned nodes and lowers disruption for users.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->