### PR TITLE
fix: ipam subnets do not exists warning

### DIFF
--- a/pkg/controllers/node/ipam/controller.go
+++ b/pkg/controllers/node/ipam/controller.go
@@ -64,6 +64,10 @@ func (c *Controller) Reconcile(ctx context.Context, n *corev1.Node) (reconcile.R
 
 	err := c.nodeIpamProvider.OccupyNodeIPs(n)
 	if err != nil {
+		if err == nodeipam.ErrNoSubnetFound {
+			return reconcile.Result{RequeueAfter: templateRepeatPeriod}, nil
+		}
+
 		return reconcile.Result{RequeueAfter: templateRepeatPeriod}, err
 	}
 

--- a/pkg/providers/nodeipam/errors.go
+++ b/pkg/providers/nodeipam/errors.go
@@ -1,0 +1,22 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package nodeipam
+
+import "github.com/pkg/errors"
+
+// ErrNoSubnetFound is returned when no subnets are available for IPAM
+var ErrNoSubnetFound = errors.New("no subnets available for IPAM")

--- a/pkg/providers/nodeipam/nodeipam.go
+++ b/pkg/providers/nodeipam/nodeipam.go
@@ -156,7 +156,7 @@ func (p *DefaultProvider) ReleaseCIDR(subnet string) error {
 
 func (p *DefaultProvider) OccupyNodeIPs(node *corev1.Node) error {
 	if len(p.subnets) == 0 {
-		return fmt.Errorf("no subnets available for IPAM")
+		return ErrNoSubnetFound
 	}
 
 	return p.updateNodeIPs(node, func(subnet *ipam.IPPool, ip net.IP) error {
@@ -194,7 +194,7 @@ func (s *DefaultProvider) OccupyIP(subnet string) (net.IP, error) {
 
 func (p *DefaultProvider) ReleaseNodeIPs(node *corev1.Node) error {
 	if len(p.subnets) == 0 {
-		return fmt.Errorf("no subnets available for IPAM")
+		return ErrNoSubnetFound
 	}
 
 	return p.updateNodeIPs(node, func(subnet *ipam.IPPool, ip net.IP) error {


### PR DESCRIPTION
Proxmox nodes can use different subnets than Kubernetes nodes. We should suppress noisy warnings about subnets that are not found in the proxmox cluster.

# Pull Request

## What? (description)

fix: ipam subnets do not exists warning

## Why? (reasoning)

https://github.com/sergelogvinov/karpenter-provider-proxmox/issues/70#issuecomment-3393962975

## Acceptance

Please use the following checklist:

- [ ] you linked an issue (if applicable)
- [ ] you included tests (if applicable)
- [ ] you linted your code (`make lint`)
- [ ] you linted your code (`make unit`)

> See `make help` for a description of the available targets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Bug Fixes
  - Node IP allocation now treats "no subnet available" as a transient condition: it retries after a short interval without surfacing an error, reducing false error reports and failed reconciliations.
  - Other allocation errors continue to retry with error visibility to ensure proper alerting.

- Refactor
  - Consolidated the "no subnets available" condition behind a shared sentinel to standardize behavior and diagnostics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->