### PR TITLE
fix: network trunk and mtu options

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/mitchellh/hashstructure/v2 v2.0.2
 	github.com/pkg/errors v0.9.1
 	github.com/samber/lo v1.52.0
-	github.com/sergelogvinov/go-proxmox v0.0.0-20250920041813-b003ecb58e03
+	github.com/sergelogvinov/go-proxmox v0.0.0-20251026220537-53535c777228
 	github.com/spf13/cobra v1.10.1
 	github.com/stretchr/testify v1.11.1
 	go.uber.org/multierr v1.11.0

--- a/go.sum
+++ b/go.sum
@@ -158,8 +158,8 @@ github.com/rogpeppe/go-internal v1.13.1/go.mod h1:uMEvuHeurkdAXX61udpOXGD/AzZDWN
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/samber/lo v1.52.0 h1:Rvi+3BFHES3A8meP33VPAxiBZX/Aws5RxrschYGjomw=
 github.com/samber/lo v1.52.0/go.mod h1:4+MXEGsJzbKGaUEQFKBq2xtfuznW9oz/WrgyzMzRoM0=
-github.com/sergelogvinov/go-proxmox v0.0.0-20250920041813-b003ecb58e03 h1:VgJ9fgOADXLW72oMAjOM6PAA9qbqibhqnuqQfpB49k0=
-github.com/sergelogvinov/go-proxmox v0.0.0-20250920041813-b003ecb58e03/go.mod h1:vSTg/WC771SByc5087tu7uyGaXUv6fS8q3ak2X+xwqk=
+github.com/sergelogvinov/go-proxmox v0.0.0-20251026220537-53535c777228 h1:j10MCEFMy4+M23TGCjAAMhdZX8e+CSsw8T9li8eWdS4=
+github.com/sergelogvinov/go-proxmox v0.0.0-20251026220537-53535c777228/go.mod h1:vSTg/WC771SByc5087tu7uyGaXUv6fS8q3ak2X+xwqk=
 github.com/sirupsen/logrus v1.9.4-0.20230606125235-dd1b4c2e81af h1:Sp5TG9f7K39yfB+If0vjp97vuT74F72r8hfRpP8jLU0=
 github.com/sirupsen/logrus v1.9.4-0.20230606125235-dd1b4c2e81af/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVsIT4qYEQ=
 github.com/spf13/cobra v1.10.1 h1:lJeBwCfmrnXthfAupyUTzJ/J4Nc1RsHC/mSRU2dll/s=

--- a/pkg/providers/instance/cloudinit/utils.go
+++ b/pkg/providers/instance/cloudinit/utils.go
@@ -65,6 +65,10 @@ func GetNetworkConfigFromVirtualMachineConfig(vmc *proxmox.VirtualMachineConfig,
 			MacAddr: params.Virtio,
 		}
 
+		if params.MTU != nil && *params.MTU != 0 {
+			iface.MTU = uint32(*params.MTU)
+		}
+
 		if i, ok := nodeIfaces[params.Bridge]; ok {
 			iface.NodeAddress4 = i.Address4
 			iface.NodeAddress6 = i.Address6

--- a/pkg/providers/instance/cloudinit/utils_test.go
+++ b/pkg/providers/instance/cloudinit/utils_test.go
@@ -40,6 +40,26 @@ func TestGetNetworkConfigFromVirtualMachineConfig(t *testing.T) {
 			network:  cloudinit.NetworkConfig{},
 		},
 		{
+			name: "1-interface",
+			template: &proxmox.VirtualMachineConfig{
+				Net0:       "virtio=BC:24:11:CD:B9:41,bridge=vmbr0,firewall=1,mtu=1,tag=70,trunks=70,100,200",
+				IPConfig0:  "ip=dhcp,ip6=auto",
+				Nameserver: "1.1.1.1 2001:4860:4860::8888",
+			},
+			network: cloudinit.NetworkConfig{
+				Interfaces: []cloudinit.InterfaceConfig{
+					{
+						Name:    "eth0",
+						MacAddr: "BC:24:11:CD:B9:41",
+						DHCPv4:  true,
+						SLAAC:   true,
+						MTU:     1,
+					},
+				},
+				NameServers: []string{"1.1.1.1", "2001:4860:4860::8888"},
+			},
+		},
+		{
 			name: "2-interfaces",
 			template: &proxmox.VirtualMachineConfig{
 				Net0:         "virtio=BC:24:11:CD:B9:41,bridge=vmbr0,firewall=1,mtu=1500",
@@ -56,11 +76,13 @@ func TestGetNetworkConfigFromVirtualMachineConfig(t *testing.T) {
 						MacAddr: "BC:24:11:CD:B9:41",
 						DHCPv4:  true,
 						SLAAC:   true,
+						MTU:     1500,
 					},
 					{
 						Name:     "eth1",
 						MacAddr:  "BC:24:11:EE:9A:23",
 						Address4: []string{"1.2.3.4/24"},
+						MTU:      1400,
 					},
 				},
 				NameServers:   []string{"1.1.1.1", "2001:4860:4860::8888"},


### PR DESCRIPTION
# Pull Request

## What? (description)

Redefines the default MTU when an explicit MTU value is provided. Bumps go-proxmox and adds support to parse the trunks option.
## Why? (reasoning)

fix: #106

## Acceptance

Please use the following checklist:

- [ ] you linked an issue (if applicable)
- [ ] you included tests (if applicable)
- [ ] you linted your code (`make lint`)
- [ ] you linted your code (`make unit`)

> See `make help` for a description of the available targets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added MTU (Maximum Transmission Unit) propagation for VM network interfaces during network configuration parsing.

* **Tests**
  * Added and extended test coverage for network configuration with MTU value handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->