### PR TITLE
fix: default mtu size

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -115,7 +115,7 @@ build: ## Build
 
 .PHONY: run
 run: ## Run
-	go run ./cmd/controller -cloud-config=cloud.yaml -disable-leader-election -log-level=debug -health-probe-port=8081 -metrics-port=8080 -log-level=debug
+	go run ./cmd/controller -cloud-config=cloud.yaml -disable-leader-election -log-level=debug -health-probe-port=8081 -metrics-port=8080
 
 .PHONY: lint
 lint: ## Lint Code

--- a/pkg/providers/instance/cloudinit/utils.go
+++ b/pkg/providers/instance/cloudinit/utils.go
@@ -65,7 +65,7 @@ func GetNetworkConfigFromVirtualMachineConfig(vmc *proxmox.VirtualMachineConfig,
 			MacAddr: params.Virtio,
 		}
 
-		if params.MTU != nil && *params.MTU != 0 {
+		if params.MTU != nil {
 			iface.MTU = uint32(*params.MTU)
 		}
 
@@ -74,6 +74,14 @@ func GetNetworkConfigFromVirtualMachineConfig(vmc *proxmox.VirtualMachineConfig,
 			iface.NodeAddress6 = i.Address6
 			iface.NodeGateway4 = i.Gateway4
 			iface.NodeGateway6 = i.Gateway6
+
+			if iface.MTU == 0 || iface.MTU == 1 {
+				iface.MTU = i.MTU
+			}
+		}
+
+		if iface.MTU == 0 {
+			iface.MTU = 1500
 		}
 
 		ipparams := goproxmox.VMCloudInitIPConfig{}


### PR DESCRIPTION
# Pull Request

## What? (description)

Proxmox uses the bridge’s MTU size by default if no other value is specified.

## Why? (reasoning)

#106

## Acceptance

Please use the following checklist:

- [ ] you linked an issue (if applicable)
- [ ] you included tests (if applicable)
- [ ] you linted your code (`make lint`)
- [ ] you linted your code (`make unit`)

> See `make help` for a description of the available targets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Network interface MTU tracking added with propagation from node interfaces and sensible defaults (including jumbo frame support).

* **Bug Fixes**
  * Improved interface filtering to avoid skipping valid interfaces.
  * MTU handling refined to honor provided values, inherit from node interfaces when appropriate, and fall back to 1500.

* **Tests**
  * Expanded tests covering MTU propagation and defaulting scenarios.

* **Chores**
  * Removed duplicate controller log-level flag for cleaner logging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->