### PR TITLE
fix: find instancetype by capacity

### DIFF
--- a/pkg/cloudprovider/cloudprovider.go
+++ b/pkg/cloudprovider/cloudprovider.go
@@ -231,6 +231,10 @@ func (c CloudProvider) List(ctx context.Context) ([]*karpv1.NodeClaim, error) {
 			log.V(1).Info("Failed to resolve instance type from node", "node", node.Name, "error", err)
 		}
 
+		if instanceType != nil {
+			log.V(1).Info("instanceType claim", "node", node.Name, "instanceTypeName", instanceType.Name, "instanceTypeLabel", node.Labels[corev1.LabelInstanceTypeStable])
+		}
+
 		nc, err := c.nodeToNodeClaim(ctx, instanceType, &node)
 		if err != nil {
 			log.Error(err, "Failed to convert nodeclaim from node", "node", node.Name)

--- a/pkg/controllers/nodetemplateunmanagedclass/status/instancetemplate.go
+++ b/pkg/controllers/nodetemplateunmanagedclass/status/instancetemplate.go
@@ -45,6 +45,10 @@ func (i *InstanceTemplate) Reconcile(ctx context.Context, templateClass *v1alpha
 		return reconcile.Result{}, nil
 	}
 
+	if err := i.instanceTemplateProvider.UpdateInstanceTemplates(ctx); err != nil {
+		return reconcile.Result{RequeueAfter: templateScanPeriod}, nil //nolint:nilerr
+	}
+
 	templates := i.instanceTemplateProvider.ListWithFilter(ctx, func(info *instancetemplate.InstanceTemplateInfo) bool {
 		if (templateClass.Spec.TemplateName != "" && info.Name != templateClass.Spec.TemplateName) ||
 			(templateClass.Spec.Region != "" && info.Region != templateClass.Spec.Region) {

--- a/pkg/providers/cloudcapacity/cloudcapacity.go
+++ b/pkg/providers/cloudcapacity/cloudcapacity.go
@@ -267,6 +267,10 @@ func (p *DefaultProvider) UpdateNodeCapacity(ctx context.Context) error {
 
 	log.V(1).Info("Syncing finished", "nodes", len(capacityInfo))
 
+	for key, info := range capacityInfo {
+		log.V(4).Info("Node capacity available", "node", key, "cpu", info.Allocatable.Cpu().String(), "memory", info.Allocatable.Memory().String())
+	}
+
 	p.capacityInfo = capacityInfo
 	p.networkInfo = networkIfaceInfo
 	p.zoneList = zoneList


### PR DESCRIPTION
# Pull Request

## What? (description)

Backward compatibility in cases where the instance was created manually.

## Why? (reasoning)

## Acceptance

Please use the following checklist:

- [ ] you linked an issue (if applicable)
- [ ] you included tests (if applicable)
- [ ] you linted your code (`make lint`)
- [ ] you linted your code (`make unit`)

> See `make help` for a description of the available targets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added capacity-based fallback to select an instance type by matching CPU/memory/pods and choosing the most cost-effective option.
  * Exposed a filtered instance-type listing to allow querying instance types by custom criteria.

* **Improvements**
  * Improved observability with additional logs for instance-type resolution and per-node capacity details.
  * Instance template updates now trigger automatic requeueing on transient errors to retry scanning.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->