### PR TITLE
refactor: enhance instance type with capacity

### DIFF
--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -68,6 +68,7 @@ func main() {
 			op.KubernetesBootstrapProvider,
 			op.InstanceProvider,
 			op.InstanceTemplateProvider,
+			op.InstanceTypeProvider,
 			op.CloudCapacityProvider,
 			op.NodeIpamController,
 		)...).

--- a/pkg/cloudprovider/cloudprovider.go
+++ b/pkg/cloudprovider/cloudprovider.go
@@ -116,11 +116,11 @@ func (c CloudProvider) Create(ctx context.Context, nodeClaim *karpv1.NodeClaim) 
 		return nil, fmt.Errorf("resolving instance types, %w", err)
 	}
 
+	log.Info("Resolved acceptable instance types", "count", len(instanceTypes))
+
 	if len(instanceTypes) == 0 {
 		return nil, cloudprovider.NewInsufficientCapacityError(fmt.Errorf("all requested instance types were unavailable during launch"))
 	}
-
-	log.Info("Successfully resolved instance types", "count", len(instanceTypes))
 
 	node, err := c.instanceProvider.Create(ctx, nodeClaim, nodeClass, instanceTypes)
 	if err != nil {
@@ -232,7 +232,7 @@ func (c CloudProvider) List(ctx context.Context) ([]*karpv1.NodeClaim, error) {
 		}
 
 		if instanceType != nil {
-			log.V(1).Info("instanceType claim", "node", node.Name, "instanceTypeName", instanceType.Name, "instanceTypeLabel", node.Labels[corev1.LabelInstanceTypeStable])
+			log.V(4).Info("instanceType claim", "node", node.Name, "instanceTypeName", instanceType.Name, "instanceTypeLabel", node.Labels[corev1.LabelInstanceTypeStable])
 		}
 
 		nc, err := c.nodeToNodeClaim(ctx, instanceType, &node)

--- a/pkg/controllers/controllers.go
+++ b/pkg/controllers/controllers.go
@@ -36,6 +36,7 @@ import (
 	"github.com/sergelogvinov/karpenter-provider-proxmox/pkg/providers/cloudcapacity"
 	"github.com/sergelogvinov/karpenter-provider-proxmox/pkg/providers/instance"
 	"github.com/sergelogvinov/karpenter-provider-proxmox/pkg/providers/instancetemplate"
+	"github.com/sergelogvinov/karpenter-provider-proxmox/pkg/providers/instancetype"
 	"github.com/sergelogvinov/karpenter-provider-proxmox/pkg/providers/nodeipam"
 
 	"k8s.io/utils/clock"
@@ -52,6 +53,7 @@ func NewControllers(ctx context.Context, mgr manager.Manager, clk clock.Clock,
 	kubernetesBootstrapProvider bootstrap.Provider,
 	instanceProvider instance.Provider,
 	instanceTemplateProvider instancetemplate.Provider,
+	instanceTypeProvider instancetype.Provider,
 	cloudCapacityProvider cloudcapacity.Provider,
 	nodeIpamProvider nodeipam.Provider,
 ) []controller.Controller {
@@ -65,7 +67,7 @@ func NewControllers(ctx context.Context, mgr manager.Manager, clk clock.Clock,
 		nodetemplateunmanagedclasshash.NewController(kubeClient),
 		nodetemplateunmanagedclassstatus.NewController(kubeClient, instanceTemplateProvider),
 		cloudcapacitynode.NewController(cloudCapacityProvider),
-		cloudcapacitynodeload.NewController(cloudCapacityProvider),
+		cloudcapacitynodeload.NewController(cloudCapacityProvider, instanceTypeProvider),
 		nodeipamctl.NewController(kubeClient, nodeIpamProvider),
 	}
 

--- a/pkg/controllers/providers/cloudcapacity/nodeload/controller.go
+++ b/pkg/controllers/providers/cloudcapacity/nodeload/controller.go
@@ -27,6 +27,7 @@ import (
 	"go.uber.org/multierr"
 
 	"github.com/sergelogvinov/karpenter-provider-proxmox/pkg/providers/cloudcapacity"
+	"github.com/sergelogvinov/karpenter-provider-proxmox/pkg/providers/instancetype"
 
 	controllerruntime "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
@@ -39,11 +40,13 @@ const (
 
 type Controller struct {
 	cloudCapacityProvider cloudcapacity.Provider
+	instanceTypeProvider  instancetype.Provider
 }
 
-func NewController(cloudCapacityProvider cloudcapacity.Provider) *Controller {
+func NewController(cloudCapacityProvider cloudcapacity.Provider, instanceTypeProvider instancetype.Provider) *Controller {
 	return &Controller{
 		cloudCapacityProvider: cloudCapacityProvider,
+		instanceTypeProvider:  instanceTypeProvider,
 	}
 }
 
@@ -56,6 +59,7 @@ func (c *Controller) Reconcile(ctx context.Context) (reconciler.Result, error) {
 
 	work := []func(ctx context.Context) error{
 		c.cloudCapacityProvider.UpdateNodeLoad,
+		c.instanceTypeProvider.UpdateInstanceTypeOfferings,
 	}
 
 	errs := make([]error, len(work))

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -84,6 +84,12 @@ func NewOperator(ctx context.Context, operator *operator.Operator) (context.Cont
 		os.Exit(1)
 	}
 
+	if err = instanceTypeProvider.UpdateInstanceTypeOfferings(ctx); err != nil {
+		log.FromContext(ctx).Error(err, "failed to update instance type offerings")
+
+		os.Exit(1)
+	}
+
 	instanceProvider, err := instance.NewProvider(
 		ctx,
 		operator.KubernetesInterface,

--- a/pkg/providers/instance/cloudinit/utils_test.go
+++ b/pkg/providers/instance/cloudinit/utils_test.go
@@ -141,7 +141,10 @@ func TestGetNetworkConfigFromVirtualMachineConfig(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(fmt.Sprint(tt.name), func(t *testing.T) {
 			result := cloudinit.GetNetworkConfigFromVirtualMachineConfig(tt.template, nodeIfaces)
-			assert.Equal(tt.network, result)
+
+			assert.ElementsMatch(tt.network.Interfaces, result.Interfaces)
+			assert.Equal(tt.network.NameServers, result.NameServers)
+			assert.Equal(tt.network.SearchDomains, result.SearchDomains)
 		})
 	}
 }

--- a/pkg/providers/instance/errors.go
+++ b/pkg/providers/instance/errors.go
@@ -1,0 +1,22 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package instance
+
+import "github.com/pkg/errors"
+
+// ErrNoZoneFound is returned when no zones are available
+var ErrNoZoneFound = errors.New("no zones available")

--- a/pkg/providers/instance/instance_placement_test.go
+++ b/pkg/providers/instance/instance_placement_test.go
@@ -1,0 +1,305 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package instance
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	corev1 "k8s.io/api/core/v1"
+
+	karpv1 "sigs.k8s.io/karpenter/pkg/apis/v1"
+	"sigs.k8s.io/karpenter/pkg/cloudprovider"
+	"sigs.k8s.io/karpenter/pkg/scheduling"
+)
+
+func TestGetValuesByKey(t *testing.T) {
+	opIn := corev1.NodeSelectorOpIn
+
+	tests := []struct {
+		name         string
+		instanceType *cloudprovider.InstanceType
+		defaults     []string
+		expect       []string
+	}{
+		{
+			name: "no-restrictions",
+			instanceType: &cloudprovider.InstanceType{
+				Name: "type-1",
+				Offerings: cloudprovider.Offerings{
+					&cloudprovider.Offering{
+						Available:    true,
+						Price:        1.0,
+						Requirements: scheduling.NewRequirements(),
+					},
+					&cloudprovider.Offering{
+						Available:    true,
+						Price:        2.0,
+						Requirements: scheduling.NewRequirements(),
+					},
+				},
+			},
+			defaults: []string{"us-west-1", "us-east-1"},
+			expect:   []string{"us-west-1", "us-east-1"},
+		},
+		{
+			name: "with-restriction",
+			instanceType: &cloudprovider.InstanceType{
+				Name: "type-1",
+				Offerings: cloudprovider.Offerings{
+					&cloudprovider.Offering{
+						Available: true,
+						Price:     1.0,
+						Requirements: scheduling.NewRequirements(
+							scheduling.NewRequirement(corev1.LabelTopologyRegion, opIn, "us-west-1"),
+						),
+					},
+					&cloudprovider.Offering{
+						Available: true,
+						Price:     2.0,
+						Requirements: scheduling.NewRequirements(
+							scheduling.NewRequirement(corev1.LabelTopologyRegion, opIn, "us-west-1"),
+						),
+					},
+				},
+			},
+			defaults: []string{"us-west-1", "us-east-1"},
+			expect:   []string{"us-west-1"},
+		},
+		{
+			name: "with-different-restriction",
+			instanceType: &cloudprovider.InstanceType{
+				Name: "type-1",
+				Offerings: cloudprovider.Offerings{
+					&cloudprovider.Offering{
+						Available: true,
+						Price:     1.0,
+						Requirements: scheduling.NewRequirements(
+							scheduling.NewRequirement(corev1.LabelTopologyRegion, opIn, "us-west-1"),
+						),
+					},
+					&cloudprovider.Offering{
+						Available: true,
+						Price:     2.0,
+						Requirements: scheduling.NewRequirements(
+							scheduling.NewRequirement(corev1.LabelTopologyRegion, opIn, "us-east-1"),
+						),
+					},
+				},
+			},
+			defaults: []string{"us-west-1", "us-east-1"},
+			expect:   []string{"us-west-1", "us-east-1"},
+		},
+		{
+			name: "with-different-regions",
+			instanceType: &cloudprovider.InstanceType{
+				Name: "type-1",
+				Offerings: cloudprovider.Offerings{
+					&cloudprovider.Offering{
+						Available: true,
+						Price:     1.0,
+						Requirements: scheduling.NewRequirements(
+							scheduling.NewRequirement(corev1.LabelTopologyRegion, opIn, "us-west-1"),
+						),
+					},
+					&cloudprovider.Offering{
+						Available: true,
+						Price:     2.0,
+						Requirements: scheduling.NewRequirements(
+							scheduling.NewRequirement(corev1.LabelTopologyRegion, opIn, "us-east-2"),
+						),
+					},
+				},
+			},
+			defaults: []string{"us-west-1", "us-east-1"},
+			expect:   []string{"us-west-1"},
+		},
+		{
+			name: "empty-regions",
+			instanceType: &cloudprovider.InstanceType{
+				Name: "type-1",
+				Offerings: cloudprovider.Offerings{
+					&cloudprovider.Offering{
+						Available: true,
+						Price:     1.0,
+						Requirements: scheduling.NewRequirements(
+							scheduling.NewRequirement(corev1.LabelTopologyRegion, opIn, "us-west-1"),
+						),
+					},
+					&cloudprovider.Offering{
+						Available: true,
+						Price:     2.0,
+						Requirements: scheduling.NewRequirements(
+							scheduling.NewRequirement(corev1.LabelTopologyRegion, opIn, "us-east-2"),
+						),
+					},
+				},
+			},
+			defaults: []string{},
+			expect:   []string{"us-west-1", "us-east-2"},
+		},
+	}
+
+	for _, tt := range tests {
+		res := getValuesByKey(tt.instanceType, corev1.LabelTopologyRegion, tt.defaults)
+
+		assert.Equal(t, tt.expect, res, tt.name)
+	}
+}
+
+// nolint:dupl
+func TestGetCapacityType(t *testing.T) {
+	opIn := corev1.NodeSelectorOpIn
+
+	tests := []struct {
+		name         string
+		nodeClaim    *karpv1.NodeClaim
+		instanceType *cloudprovider.InstanceType
+		region       string
+		zone         string
+		expect       string
+	}{
+		{
+			name: "spot-available",
+			nodeClaim: &karpv1.NodeClaim{
+				Spec: karpv1.NodeClaimSpec{
+					Requirements: []karpv1.NodeSelectorRequirementWithMinValues{
+						{NodeSelectorRequirement: corev1.NodeSelectorRequirement{Key: corev1.LabelTopologyRegion, Operator: opIn, Values: []string{"us-west-1"}}},
+						{NodeSelectorRequirement: corev1.NodeSelectorRequirement{Key: corev1.LabelTopologyZone, Operator: opIn, Values: []string{"us-west-1a", "us-west-1b"}}},
+						{NodeSelectorRequirement: corev1.NodeSelectorRequirement{Key: karpv1.CapacityTypeLabelKey, Operator: opIn, Values: []string{karpv1.CapacityTypeSpot, karpv1.CapacityTypeOnDemand}}},
+					},
+				},
+			},
+			instanceType: &cloudprovider.InstanceType{
+				Name: "type-1",
+				Offerings: cloudprovider.Offerings{
+					&cloudprovider.Offering{
+						Available: true,
+						Price:     1.0,
+						Requirements: scheduling.NewRequirements(
+							scheduling.NewRequirement(karpv1.CapacityTypeLabelKey, opIn, karpv1.CapacityTypeSpot),
+						),
+					},
+				},
+			},
+			region: "us-west-1",
+			zone:   "us-west-1a",
+			expect: karpv1.CapacityTypeSpot,
+		},
+		{
+			name: "spot-unavailable-use-on-demand",
+			nodeClaim: &karpv1.NodeClaim{
+				Spec: karpv1.NodeClaimSpec{
+					Requirements: []karpv1.NodeSelectorRequirementWithMinValues{
+						{NodeSelectorRequirement: corev1.NodeSelectorRequirement{Key: corev1.LabelTopologyRegion, Operator: opIn, Values: []string{"us-west-1"}}},
+						{NodeSelectorRequirement: corev1.NodeSelectorRequirement{Key: corev1.LabelTopologyZone, Operator: opIn, Values: []string{"us-west-1a", "us-west-1b"}}},
+						{NodeSelectorRequirement: corev1.NodeSelectorRequirement{Key: karpv1.CapacityTypeLabelKey, Operator: opIn, Values: []string{karpv1.CapacityTypeSpot, karpv1.CapacityTypeOnDemand}}},
+					},
+				},
+			},
+			instanceType: &cloudprovider.InstanceType{
+				Name: "type-1",
+				Offerings: cloudprovider.Offerings{
+					&cloudprovider.Offering{
+						Available: true,
+						Price:     1.0,
+						Requirements: scheduling.NewRequirements(
+							scheduling.NewRequirement(karpv1.CapacityTypeLabelKey, opIn, karpv1.CapacityTypeOnDemand),
+						),
+					},
+				},
+			},
+			region: "us-west-1",
+			zone:   "us-west-1a",
+			expect: karpv1.CapacityTypeOnDemand,
+		},
+		{
+			name: "no-capacity-type-requested-use-on-demand",
+			nodeClaim: &karpv1.NodeClaim{
+				Spec: karpv1.NodeClaimSpec{
+					Requirements: []karpv1.NodeSelectorRequirementWithMinValues{
+						{NodeSelectorRequirement: corev1.NodeSelectorRequirement{Key: corev1.LabelTopologyRegion, Operator: opIn, Values: []string{"us-west-1"}}},
+						{NodeSelectorRequirement: corev1.NodeSelectorRequirement{Key: corev1.LabelTopologyZone, Operator: opIn, Values: []string{"us-west-1a", "us-west-1b"}}},
+					},
+				},
+			},
+			instanceType: &cloudprovider.InstanceType{
+				Name: "type-1",
+				Offerings: cloudprovider.Offerings{
+					&cloudprovider.Offering{
+						Available: true,
+						Price:     1.0,
+						Requirements: scheduling.NewRequirements(
+							scheduling.NewRequirement(karpv1.CapacityTypeLabelKey, opIn, karpv1.CapacityTypeSpot),
+						),
+					},
+					&cloudprovider.Offering{
+						Available: true,
+						Price:     1.0,
+						Requirements: scheduling.NewRequirements(
+							scheduling.NewRequirement(karpv1.CapacityTypeLabelKey, opIn, karpv1.CapacityTypeOnDemand),
+						),
+					},
+				},
+			},
+			region: "us-west-1",
+			zone:   "us-west-1a",
+			expect: karpv1.CapacityTypeOnDemand,
+		},
+		{
+			name: "reserved-available",
+			nodeClaim: &karpv1.NodeClaim{
+				Spec: karpv1.NodeClaimSpec{
+					Requirements: []karpv1.NodeSelectorRequirementWithMinValues{
+						{NodeSelectorRequirement: corev1.NodeSelectorRequirement{Key: corev1.LabelTopologyRegion, Operator: opIn, Values: []string{"us-west-1"}}},
+						{NodeSelectorRequirement: corev1.NodeSelectorRequirement{Key: corev1.LabelTopologyZone, Operator: opIn, Values: []string{"us-west-1a", "us-west-1b"}}},
+						{NodeSelectorRequirement: corev1.NodeSelectorRequirement{Key: karpv1.CapacityTypeLabelKey, Operator: opIn, Values: []string{karpv1.CapacityTypeReserved, karpv1.CapacityTypeSpot}}},
+					},
+				},
+			},
+			instanceType: &cloudprovider.InstanceType{
+				Name: "type-1",
+				Offerings: cloudprovider.Offerings{
+					&cloudprovider.Offering{
+						Available: true,
+						Price:     1.0,
+						Requirements: scheduling.NewRequirements(
+							scheduling.NewRequirement(karpv1.CapacityTypeLabelKey, opIn, karpv1.CapacityTypeOnDemand),
+						),
+					},
+					&cloudprovider.Offering{
+						Available: true,
+						Price:     1.0,
+						Requirements: scheduling.NewRequirements(
+							scheduling.NewRequirement(karpv1.CapacityTypeLabelKey, opIn, karpv1.CapacityTypeReserved),
+						),
+					},
+				},
+			},
+			region: "us-west-1",
+			zone:   "us-west-1a",
+			expect: karpv1.CapacityTypeReserved,
+		},
+	}
+
+	for _, tt := range tests {
+		res := getCapacityType(tt.nodeClaim, tt.instanceType, tt.region, tt.zone)
+
+		assert.Equal(t, tt.expect, res, tt.name)
+	}
+}

--- a/pkg/providers/instancetype/generate.go
+++ b/pkg/providers/instancetype/generate.go
@@ -22,15 +22,16 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 
+	karpv1 "sigs.k8s.io/karpenter/pkg/apis/v1"
 	"sigs.k8s.io/karpenter/pkg/cloudprovider"
-	"sigs.k8s.io/karpenter/pkg/scheduling"
 )
 
 type InstanceTypeStatic struct {
 	Name         string                              `json:"name,omitempty"`
 	Capacity     corev1.ResourceList                 `json:"capacity,omitempty"`
+	CapacityType string                              `json:"capacitytype,omitempty"`
 	Overhead     *cloudprovider.InstanceTypeOverhead `json:"overhead,omitempty"`
-	Requirements scheduling.Requirements             `json:"requirements,omitempty"`
+	Offerings    cloudprovider.Offerings             `json:"offerings,omitempty"`
 }
 
 type InstanceTypeOptions struct {
@@ -69,8 +70,9 @@ func (o *InstanceTypeOptions) Generate() []*InstanceTypeStatic {
 			}
 
 			instanceType := InstanceTypeStatic{
-				Name:     makeGenericInstanceTypeName(cpu, memFactor),
-				Capacity: capacity,
+				Name:         makeGenericInstanceTypeName(cpu, memFactor),
+				Capacity:     capacity,
+				CapacityType: karpv1.CapacityTypeOnDemand,
 			}
 
 			if o.KubeletOverhead || o.SystemOverhead || o.EvictionThreshold {


### PR DESCRIPTION
# Pull Request

## What? (description)

Enhance instance type handling with capacity types

## Why? (reasoning)

## Acceptance

Please use the following checklist:

- [ ] you linked an issue (if applicable)
- [ ] you included tests (if applicable)
- [ ] you linted your code (`make lint`)
- [ ] you linted your code (`make unit`)

> See `make help` for a description of the available targets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Multiple capacity types (OnDemand/Reserved/Spot) supported and propagated to VMs.

* **Improvements**
  * Capacity type included in VM descriptions and node labels.
  * Region/zone selection refined using per-offering filters; explicit handling/log when no zones found.
  * Instance-type offerings refreshed at operator/controller startup and wired into controllers for placement decisions.
  * Adjusted logging verbosity for instance-type resolution.

* **Refactor**
  * Instance-type/offering model reworked to carry capacity and offering data.

* **Tests**
  * Added unit tests for region/value extraction and capacity-type resolution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->