### PR TITLE
feat: add resource pool support for ProxmoxNodeClass

### DIFF
--- a/docs/deploy/karpenter-provider-proxmox-edge.yml
+++ b/docs/deploy/karpenter-provider-proxmox-edge.yml
@@ -306,6 +306,17 @@ spec:
                   type: string
                 maxItems: 10
                 type: array
+              resourcePool:
+                description: |-
+                  ResourcePool is the Proxmox resource pool name where VMs will be placed.
+                  If specified, cloned VMs will be added to this pool during creation.
+                  The pool must already exist in Proxmox.
+                  Supports nested pools up to 3 levels (e.g., "parent/child/grandchild").
+                  Note: PVE 9+ requires pool names to start with a letter; PVE 8 allows
+                  names starting with digits but this is deprecated.
+                maxLength: 64
+                pattern: ^[a-zA-Z0-9][a-zA-Z0-9._-]*(/[a-zA-Z0-9][a-zA-Z0-9._-]*){0,2}$
+                type: string
             required:
             - instanceTemplateRef
             type: object

--- a/docs/nodeclass.md
+++ b/docs/nodeclass.md
@@ -74,6 +74,10 @@ spec:
     - name: kubernetes
       # Interface to apply the security group
       interface: net0
+
+  # ResourcePool is the Proxmox resource pool name where VMs will be placed.
+  # Optional
+  resourcePool: k8s-pool
 ```
 
 ### Parameters:
@@ -112,6 +116,13 @@ spec:
   - `name` - The name of the security group.
   - `interface` - The interface to apply the security group.
 
+* `resourcePool` - The Proxmox resource pool name where VMs will be placed. Optional.
+  If specified, cloned VMs will be added to this pool during creation.
+  The pool must already exist in Proxmox.
+  Supports nested pools up to 3 levels (e.g., `parent/child/grandchild`).
+  Note: PVE 9+ requires pool names to start with a letter; PVE 8 allows names starting with digits but this is deprecated.
+  This option does __not__ trigger drift - changes to resourcePool are ignored during drift evaluation.
+
 Karpenter supports instance drift detection when an `ProxmoxNodeClass` is updated.
 If a change affects a node, Karpenter may replace (drift) the instance to align with the new configuration.
 However, some parameters __do not trigger__ drift.
@@ -119,6 +130,7 @@ Changes to these fields are ignored during drift evaluation:
 * `tags`
 * `metadataOptions`
 * `securityGroups`
+* `resourcePool`
 
 The `ProxmoxTemplate` and `ProxmoxUnmanagedTemplate` resource definitions see [here](nodetemplateclass.md).
 

--- a/pkg/apis/crds/karpenter.proxmox.sinextra.dev_proxmoxnodeclasses.yaml
+++ b/pkg/apis/crds/karpenter.proxmox.sinextra.dev_proxmoxnodeclasses.yaml
@@ -304,6 +304,17 @@ spec:
                   type: string
                 maxItems: 10
                 type: array
+              resourcePool:
+                description: |-
+                  ResourcePool is the Proxmox resource pool name where VMs will be placed.
+                  If specified, cloned VMs will be added to this pool during creation.
+                  The pool must already exist in Proxmox.
+                  Supports nested pools up to 3 levels (e.g., "parent/child/grandchild").
+                  Note: PVE 9+ requires pool names to start with a letter; PVE 8 allows
+                  names starting with digits but this is deprecated.
+                maxLength: 64
+                pattern: ^[a-zA-Z0-9][a-zA-Z0-9._-]*(/[a-zA-Z0-9][a-zA-Z0-9._-]*){0,2}$
+                type: string
             required:
             - instanceTemplateRef
             type: object

--- a/pkg/apis/v1alpha1/nodeclass.go
+++ b/pkg/apis/v1alpha1/nodeclass.go
@@ -100,6 +100,17 @@ type ProxmoxNodeClassSpec struct {
 	// +kubebuilder:validation:MaxItems:=10
 	// +optional
 	SecurityGroups []SecurityGroups `json:"securityGroups,omitempty" hash:"ignore"`
+
+	// ResourcePool is the Proxmox resource pool name where VMs will be placed.
+	// If specified, cloned VMs will be added to this pool during creation.
+	// The pool must already exist in Proxmox.
+	// Supports nested pools up to 3 levels (e.g., "parent/child/grandchild").
+	// Note: PVE 9+ requires pool names to start with a letter; PVE 8 allows
+	// names starting with digits but this is deprecated.
+	// +kubebuilder:validation:MaxLength=64
+	// +kubebuilder:validation:Pattern=`^[a-zA-Z0-9][a-zA-Z0-9._-]*(/[a-zA-Z0-9][a-zA-Z0-9._-]*){0,2}$`
+	// +optional
+	ResourcePool string `json:"resourcePool,omitempty" hash:"ignore"`
 }
 
 // PlacementStrategy defines how nodes should be placed across zones

--- a/pkg/providers/instance/instance.go
+++ b/pkg/providers/instance/instance.go
@@ -379,6 +379,7 @@ func (p *DefaultProvider) instanceCreate(ctx context.Context,
 		Name:        nodeClaim.Name,
 		Description: fmt.Sprintf("Karpenter, class=%s, capacity=%s", nodeClass.Name, capacityType),
 		Full:        1,
+		Pool:        nodeClass.Spec.ResourcePool,
 		Storage:     storage,
 
 		CPU:          int(instanceType.Capacity.Cpu().Value()),


### PR DESCRIPTION
## Summary

This PR adds support for Proxmox resource pools in `ProxmoxNodeClass`, allowing Karpenter-provisioned VMs to be automatically placed in a specified resource pool.

### Changes

- Added `resourcePool` field to `ProxmoxNodeClassSpec` in `pkg/apis/v1alpha1/nodeclass.go`
- Updated `pkg/providers/instance/instance.go` to pass the `Pool` field to `VMCloneRequest`
- Updated CRDs in both `pkg/apis/crds/` and `charts/karpenter-provider-proxmox/crds/`
- Updated documentation in `docs/nodeclass.md`

### Problem Solved

When Karpenter provisions VMs in Proxmox, they are created without resource pool assignment. This creates organizational and operational challenges:

1. **Cluster organization**: Control plane nodes (created via Terraform or other IaC) are typically placed in resource pools, but Karpenter-created worker nodes appear outside these pools
2. **Resource tracking**: Proxmox resource pools provide aggregate resource consumption views; excluding dynamically-provisioned nodes skews capacity planning
3. **Access control**: Proxmox uses resource pools for permission boundaries; VMs outside pools may have incorrect access policies
4. **Operational visibility**: Administrators grouping VMs by pool cannot easily identify which VMs belong to a Kubernetes cluster

### Usage Example

```yaml
apiVersion: karpenter.proxmox.sinextra.dev/v1alpha1
kind: ProxmoxNodeClass
metadata:
  name: default
spec:
  region: proxmox
  resourcePool: k3s-homelab    # Simple pool
  # resourcePool: parent/child/grandchild  # Nested pool (up to 3 levels)
  instanceTemplateRef:
    kind: ProxmoxUnmanagedTemplate
    name: default
  bootDevice:
    size: 30Gi
    storage: nvme-vms
```

### Validation

The `resourcePool` field includes validation compatible with PVE 8+:
- Supports nested pools up to 3 levels (e.g., `parent/child/grandchild`)
- Allowed characters: letters, numbers, dots, underscores, hyphens
- Pattern: `^[a-zA-Z0-9][a-zA-Z0-9._-]*(/[a-zA-Z0-9][a-zA-Z0-9._-]*){0,2}$`
- Note: PVE 9+ requires pool names to start with a letter; PVE 8 allows names starting with digits but this is deprecated

### Design Decisions

1. **`hash:"ignore"` tag**: Changes to `resourcePool` do NOT trigger node replacement. Existing nodes remain functional regardless of pool membership.
2. **Optional field**: Empty value means no pool assignment (current behavior preserved).
3. **PVE 8+ compatible validation**: Pattern allows digit-starting names for PVE 8 compatibility while documenting PVE 9+ stricter requirements.
4. **No in-place update**: Unlike tags and securityGroups, pool membership cannot be changed after VM creation via Proxmox API.

### Backwards Compatibility

- Fully backwards compatible
- Existing ProxmoxNodeClass resources continue to work unchanged
- VMs created without resourcePool behave exactly as before

### Dependency Status

No changes required to go-proxmox library. The `Pool` field already exists in `VMCloneRequest`.

## Test plan

- [x] Create a resource pool in Proxmox: `pvesh create /pools --poolid test-karpenter`
- [x] Deploy ProxmoxNodeClass with `resourcePool: test-karpenter`
- [x] Trigger scale-up
- [x] Verify VM appears in pool: `pvesh get /pools/test-karpenter`
- [x] Verify node functions correctly in Kubernetes
- [x] Test with invalid pool name and verify clear error message

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional `resourcePool` field to ProxmoxNodeClass specification, allowing users to specify a Proxmox resource pool for newly cloned VMs. The specified pool must already exist and supports nested pools up to 3 levels deep.

* **Documentation**
  * Updated API documentation with ResourcePool field details and usage constraints.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->