### PR TITLE
fix: add required taint to the kubelet configuration

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -106,7 +106,7 @@ manifests: ## generate the controller-gen kubernetes manifests
 
 .PHONY: install
 install: ## Install
-	kubectl replace -f pkg/apis/crds/
+	kubectl replace --force -f pkg/apis/crds/
 
 .PHONY: build
 build: ## Build

--- a/docs/deploy/test-statefulset.yaml
+++ b/docs/deploy/test-statefulset.yaml
@@ -19,10 +19,13 @@ spec:
         fsGroup: 65534
         runAsGroup: 65534
         runAsUser: 65534
-      # tolerations:
-      #   - effect: NoSchedule
-      #     key: node-role.kubernetes.io/control-plane
+      tolerations:
+        - effect: NoSchedule
+          key: node-role.kubernetes.io/control-plane
       nodeSelector:
+        kubernetes.io/os: linux
+        # topology.kubernetes.io/region: fr-par-2
+        # node-role.kubernetes.io/logs: ""
         # node-role.kubernetes.io/control-plane: ""
         # kubernetes.io/hostname: kube-21
         # topology.kubernetes.io/zone: hvm-1

--- a/examples/talos/README.md
+++ b/examples/talos/README.md
@@ -67,8 +67,6 @@ machine:
   kubelet:
     image: ghcr.io/siderolabs/kubelet:{{ .Values.kubeletVersion }}
     defaultRuntimeSeccompProfileEnabled: true
-    extraArgs:
-      register-with-taints: "karpenter.sh/unregistered=:NoExecute"
     extraConfig:
       {{- .Kubernetes.KubeletConfiguration | toYamlPretty | nindent 6 }}
   install:

--- a/examples/talos/worker.yaml
+++ b/examples/talos/worker.yaml
@@ -9,8 +9,6 @@ machine:
   kubelet:
     image: ghcr.io/siderolabs/kubelet:{{ .Values.kubeVersion }}
     defaultRuntimeSeccompProfileEnabled: true
-    extraArgs:
-      register-with-taints: "karpenter.sh/unregistered=:NoExecute"
     extraConfig:
       {{- .Kubernetes.KubeletConfiguration | toYamlPretty | nindent 6 }}
   install:

--- a/pkg/providers/instance/cloudinit/userdata_test.go
+++ b/pkg/providers/instance/cloudinit/userdata_test.go
@@ -73,6 +73,12 @@ func TestUserData(t *testing.T) {
 			AllowedUnsafeSysctls:  []string{"kernel.msgmax", "kernel.shmmax"},
 			TopologyManagerPolicy: "best-effort",
 			ProviderID:            provider.GetProviderID(region, 100),
+			RegisterWithTaints: []instance.KubernetesTaint{
+				{
+					Key:    "example-key",
+					Effect: "NoSchedule",
+				},
+			},
 		},
 		Values: map[string]string{
 			"SSHAuthorizedKeys": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCu...,ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDk...",
@@ -129,6 +135,9 @@ write_files:
           - kernel.msgmax
           - kernel.shmmax
         providerID: proxmox://test-region/100
+        registerWithTaints:
+          - key: example-key
+            effect: NoSchedule
       values:
         SSHAuthorizedKeys: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCu...,ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDk...
     owner: root:root
@@ -154,6 +163,9 @@ write_files:
         - kernel.msgmax
         - kernel.shmmax
       providerID: proxmox://test-region/100
+      registerWithTaints:
+        - key: example-key
+          effect: NoSchedule
   - path: /etc/kubernetes/kubelet-labels.conf
     permissions: 0o600
     defer: true

--- a/pkg/providers/instance/instance_cloudinit.go
+++ b/pkg/providers/instance/instance_cloudinit.go
@@ -239,6 +239,15 @@ func (p *DefaultProvider) generateCloudInitVars(
 	}
 	userdataValues.Kubernetes.KubeletConfiguration.ProviderID = metadataValues.ProviderID
 
+	if len(userdataValues.Kubernetes.KubeletConfiguration.RegisterWithTaints) == 0 {
+		userdataValues.Kubernetes.KubeletConfiguration.RegisterWithTaints = []KubernetesTaint{
+			{
+				Key:    karpv1.UnregisteredTaintKey,
+				Effect: corev1.TaintEffectNoExecute,
+			},
+		}
+	}
+
 	userdata := string(secret.Data["user-data"])
 	if userdata == "" {
 		userdata = cloudinit.DefaultUserdata

--- a/pkg/providers/instance/types.go
+++ b/pkg/providers/instance/types.go
@@ -19,6 +19,7 @@ package instance
 import (
 	"github.com/sergelogvinov/karpenter-provider-proxmox/pkg/providers/instance/cloudinit"
 
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -34,6 +35,12 @@ type Kubernetes struct {
 	RootCA               string
 	BootstrapToken       string
 	KubeletConfiguration *KubeletConfiguration
+}
+
+type KubernetesTaint struct {
+	Key    string             `yaml:"key,omitempty"`
+	Value  string             `yaml:"value,omitempty"`
+	Effect corev1.TaintEffect `yaml:"effect,omitempty"`
 }
 
 type KubeletConfiguration struct {
@@ -119,6 +126,11 @@ type KubeletConfiguration struct {
 	// Currently only cpu, memory and local ephemeral storage for root file system are supported.
 	// See https://kubernetes.io/docs/tasks/administer-cluster/reserve-compute-resources for more detail.
 	EvictionHard map[string]string `yaml:"evictionHard,omitempty"`
+
+	// RegisterWithTaints is a list of taints to add to a node object when the kubelet registers itself.
+	// This only takes effect when registerNode is true and upon the initial registration of the node
+	// See https://kubernetes.io/docs/reference/config-api/kubelet-config.v1beta1/#kubelet-config-k8s-io-v1beta1-KubeletConfiguration
+	RegisterWithTaints []KubernetesTaint `yaml:"registerWithTaints,omitempty"`
 }
 
 // DefaultEvictionHard is the default eviction hard thresholds for Kubernetes


### PR DESCRIPTION
# Pull Request

## What? (description)

Karpenter requires a specific taint on nodes.
To support this, we need to configure the taint directly in the kubelet configuration file.

## Why? (reasoning)

## Acceptance

Please use the following checklist:

- [ ] you linked an issue (if applicable)
- [ ] you included tests (if applicable)
- [ ] you linted your code (`make lint`)
- [ ] you linted your code (`make unit`)

> See `make help` for a description of the available targets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Nodes can register with custom taints to control pod scheduling and eviction.
  * A default "unregistered" taint is applied when no custom taints are provided.

* **Chores**
  * Installation now forces replacement of Kubernetes resources during deploy.
  * StatefulSet manifests enable control-plane tolerations and select Linux nodes.
  * Example templates no longer set the kubelet "register-with-taints" argument.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->