### PR TITLE
feat: hugepages in instance types

### DIFF
--- a/docs/deploy/test-statefulset.yaml
+++ b/docs/deploy/test-statefulset.yaml
@@ -56,9 +56,11 @@ spec:
             limits:
               cpu: 2
               memory: 5Gi
+              # hugepages-1Gi: 1Gi
             requests:
               cpu: 1200m
-              memory: 4100Mi
+              memory: 3Gi
+              # hugepages-1Gi: 1Gi
   updateStrategy:
     type: RollingUpdate
   selector:

--- a/docs/instancetypes.md
+++ b/docs/instancetypes.md
@@ -62,6 +62,8 @@ The file structure looks like this:
   * `ephemeral-storage`: The boot disk size.
   * `memory`: The amount of memory.
   * `pods`: The maximum number of pods.
+  * `hugepages-1Gi` (optional): The amount of hugepages with 1Gi size.
+  * `hugepages-2Mi` (optional): The amount of hugepages with 2Mi size.
 * `overhead`: The resource overhead for the instance type, applied in the kubelet configuration file.
   * `KubeReserved`: The resources reserved for Kubernetes system components.
     * `cpu`: The amount of CPU reserved for Kubernetes.

--- a/examples/talos/user-data-values.yaml
+++ b/examples/talos/user-data-values.yaml
@@ -10,4 +10,3 @@ stringData:
   clusterSecret: ...
   clusterEndpoint: "https://api.example.com:6443"
   clusterName: proxmox
-  kubeVersion: v1.33.4

--- a/examples/talos/worker.yaml
+++ b/examples/talos/worker.yaml
@@ -7,10 +7,17 @@ machine:
   ca:
     crt: {{ .Values.machineCA }}
   kubelet:
-    image: ghcr.io/siderolabs/kubelet:{{ .Values.kubeVersion }}
+    image: ghcr.io/siderolabs/kubelet:{{ .Kubernetes.Version }}
     defaultRuntimeSeccompProfileEnabled: true
     extraConfig:
       {{- .Kubernetes.KubeletConfiguration | toYamlPretty | nindent 6 }}
+  sysfs:
+    {{- with .Resources.Hugepages1Gi }}
+    devices/system/node/node0/hugepages/hugepages-1048576kB/nr_hugepages: {{ . }}
+    {{- end }}
+    {{- with .Resources.Hugepages2Mi }}
+    devices/system/node/node0/hugepages/hugepages-2048kB/nr_hugepages: {{ . }}
+    {{- end }}
   install:
     wipe: true
   features:

--- a/pkg/providers/instance/cloudinit/userdata.go
+++ b/pkg/providers/instance/cloudinit/userdata.go
@@ -38,6 +38,11 @@ users:
     {{- end }}
 
 write_files:
+  {{- with .Resources.Hugepages2Mi }}
+  - path: /etc/sysctl.d/99-hugepages.conf
+    content: |
+      vm.nr_hugepages = {{ . }}
+  {{- end }}
   - path: /etc/karpenter.yaml
     content: |
       {{- . | toYamlPretty | nindent 6  }}

--- a/pkg/providers/instance/types.go
+++ b/pkg/providers/instance/types.go
@@ -27,11 +27,20 @@ import (
 type UserDataValues struct {
 	Metadata   cloudinit.MetaData
 	Network    cloudinit.NetworkConfig
+	Resources  Resources
 	Kubernetes Kubernetes
 	Values     map[string]string
 }
 
+type Resources struct {
+	CPU          int64 `yaml:"cpu,omitempty"`
+	Memory       int64 `yaml:"memory,omitempty"`
+	Hugepages1Gi int   `yaml:"hugepages1Gi,omitempty"`
+	Hugepages2Mi int   `yaml:"hugepages2Mi,omitempty"`
+}
+
 type Kubernetes struct {
+	Version              string
 	RootCA               string
 	BootstrapToken       string
 	KubeletConfiguration *KubeletConfiguration

--- a/pkg/providers/instancetype/generate.go
+++ b/pkg/providers/instancetype/generate.go
@@ -63,6 +63,7 @@ func (o *InstanceTypeOptions) Generate() []*InstanceTypeStatic {
 				corev1.ResourceCPU:    resource.MustParse(fmt.Sprintf("%d", cpu)),
 				corev1.ResourceMemory: resource.MustParse(fmt.Sprintf("%dM", mem*1024)),
 				corev1.ResourcePods:   resource.MustParse(fmt.Sprintf("%d", pods)),
+				// corev1.ResourceHugePagesPrefix + "1Gi": resource.MustParse(fmt.Sprintf("%dGi", 1)),
 			}
 
 			if o.Storage > 0 {


### PR DESCRIPTION
# Pull Request

## What? (description)

Add support for hugepages resource allocation in instance types

## Why? (reasoning)

## Acceptance

Please use the following checklist:

- [ ] you linked an issue (if applicable)
- [ ] you included tests (if applicable)
- [ ] you linted your code (`make lint`)
- [ ] you linted your code (`make unit`)

> See `make help` for a description of the available targets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added hugepages support (1Gi and 2Mi) for instance types and worker node configuration, including automation of host hugepage settings.
* **Documentation**
  * Instance type schema docs updated to include hugepages capacity fields.
* **Examples**
  * Example configs updated to stop pinning a specific Kubernetes version and to derive kubelet image version from the cluster version.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->